### PR TITLE
CI: run block-authority-re-entry on README changes

### DIFF
--- a/.github/workflows/finality-guard.yml
+++ b/.github/workflows/finality-guard.yml
@@ -7,12 +7,14 @@ on:
       - 'core/contracts/**'
       - 'core/schemas/**'
       - 'public/VERDICT_REFERENCE_v1.md'
+      - 'README.md'
   pull_request:
     paths:
       - 'core/axioms/**'
       - 'core/contracts/**'
       - 'core/schemas/**'
       - 'public/VERDICT_REFERENCE_v1.md'
+      - 'README.md'
 
 jobs:
   block-authority-re-entry:


### PR DESCRIPTION
Update workflow to trigger on README.md changes so authority checks run on documentation updates.