### PR TITLE
CI: avoid deadlock on doc-only changes

### DIFF
--- a/.github/workflows/finality-guard.yml
+++ b/.github/workflows/finality-guard.yml
@@ -7,12 +7,16 @@ on:
       - 'core/contracts/**'
       - 'core/schemas/**'
       - 'public/VERDICT_REFERENCE_v1.md'
+    paths-ignore:
+      - 'README.md'
   pull_request:
     paths:
       - 'core/axioms/**'
       - 'core/contracts/**'
       - 'core/schemas/**'
       - 'public/VERDICT_REFERENCE_v1.md'
+    paths-ignore:
+      - 'README.md'
 
 jobs:
   block-authority-re-entry:


### PR DESCRIPTION
Add paths-ignore for README.md to prevent workflow deadlock on documentation-only changes.