### PR TITLE
Close remaining evidence README package drift

### DIFF
--- a/evidence/README.md
+++ b/evidence/README.md
@@ -458,7 +458,7 @@ If you are entering this tree for the first time, start here:
 - issuance object: `artifact-0003/artifact-0003.json`
 - semantic cross-implementation result: `artifact-semantic-execution/CROSS_IMPLEMENTATION_STATUS.txt`
 - recorded execution component surface: `component-surface/corpiform/COMPONENT_STATUS.txt`
-- external package publication status: `package-surface/auctoriseal-0.1.2/PUBLICATION_STATUS.txt`
+- external package publication status: `package-surface/CURRENT_PACKAGE_INDEX.txt`
 
 ---
 


### PR DESCRIPTION
Replace the stale two-package README summary with the full live package chain.