### PR TITLE
Normalize package identity and license metadata

### DIFF
--- a/evidence/README.md
+++ b/evidence/README.md
@@ -40,6 +40,7 @@ Published npm package evidence currently recorded here:
 - `package-surface/verifrax-spec-0.1.0/`
 - `package-surface/verifrax-0.1.0/`
 - `package-surface/sigillarium-0.1.0/`
+
 That means the currently indexed public boundary is:
 
 1. repository integrity evidence for the initial protocol object

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@verifrax/root",
+  "name": "@verifrax/verifrax",
   "private": true,
   "packageManager": "pnpm@9.0.0",
   "scripts": {
@@ -20,5 +20,7 @@
   },
   "bin": {
     "verifrax-seal": "scripts/verifrax-seal.js"
-  }
+  },
+  "license": "Apache-2.0",
+  "version": "0.0.0"
 }

--- a/verifier/node/package.json
+++ b/verifier/node/package.json
@@ -7,5 +7,10 @@
   "scripts": {
     "verify": "node src/verifier.mjs"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "files": [
+    "dist/",
+    "README.md",
+    "LICENSE"
+  ]
 }

--- a/verifier/node/package.json
+++ b/verifier/node/package.json
@@ -3,10 +3,15 @@
   "version": "0.1.0",
   "description": "Reference deterministic verifier for the VERIFRAX protocol",
   "type": "module",
-  "main": "src/verifier.mjs",
+  "main": "dist/verifier.mjs",
   "scripts": {
     "verify": "node src/verifier.mjs"
   },
   "license": "MIT",
-  "private": true
+  "private": true,
+  "files": [
+    "dist/",
+    "README.md",
+    "LICENSE"
+  ]
 }

--- a/verifier/node/package.json
+++ b/verifier/node/package.json
@@ -8,9 +8,5 @@
     "verify": "node src/verifier.mjs"
   },
   "license": "MIT",
-  "files": [
-    "dist/",
-    "README.md",
-    "LICENSE"
-  ]
+  "private": true
 }


### PR DESCRIPTION
This change normalizes package identity to the repo-specific scoped name and aligns license metadata.

It removes duplicate or unscoped package claims while preserving the intended private boundary where already declared.
No publication or host-behavior claim is introduced.