### PR TITLE
Establish terminal recognition and terminal recourse boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,4 +362,3 @@ This repository is part of the Verifrax sovereign stack and remains bounded rela
 
 - **[ANAGNORIUM](https://github.com/Verifrax/ANAGNORIUM)** for terminal recognition
 - **[REGRESSORIUM](https://github.com/Verifrax/REGRESSORIUM)** for terminal recourse
-

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ SNAPSHOT: https://speedkit.eu/REGISTRY_SNAPSHOT.json
 
 Normative protocol authoring, evidence-root registration, and verification boundary for the governed Verifrax system.
 
+## Terminal planes
+
+- **[ANAGNORIUM](https://github.com/Verifrax/ANAGNORIUM)** — terminal recognition
+- **[REGRESSORIUM](https://github.com/Verifrax/REGRESSORIUM)** — terminal recourse
+
 ## Status
 
 * Layer: protocol authoring, evidence, and verification boundary
@@ -350,3 +355,11 @@ A change is wrong if it:
 ## License
 
 Apache License Version 2.0. See `LICENSE`.
+
+## Adjacent sovereign surfaces
+
+This repository is part of the Verifrax sovereign stack and remains bounded relative to:
+
+- **[ANAGNORIUM](https://github.com/Verifrax/ANAGNORIUM)** for terminal recognition
+- **[REGRESSORIUM](https://github.com/Verifrax/REGRESSORIUM)** for terminal recourse
+


### PR DESCRIPTION
This change wires ANAGNORIUM and REGRESSORIUM into the repository boundary.

- adds terminal recognition and terminal recourse references
- preserves one-repo one-role grammar
- extends the sovereign stack without role collision