### PR TITLE
Materialize artifact-0006 evidence surface and elevate canonical artifact chain

### DIFF
--- a/evidence/README.md
+++ b/evidence/README.md
@@ -1,5 +1,15 @@
 # VERIFRAX Evidence Index
 
+## Canonical artifact chain
+
+- **artifact-0006**
+- **artifact-0005**
+- **artifact-0004**
+- **artifact-0003**
+- **artifact-0002**
+- **artifact-0001**
+
+
 This directory is the public evidence surface for VERIFRAX.
 
 It exists so that any reviewer, claimant, challenger, auditor, or adversarial reader can inspect what was asserted, what was executed, what was observed, what was not executable, and what boundary the current evidence actually proves.
@@ -482,4 +492,3 @@ This index covers the evidence currently published under `VERIFRAX/evidence`.
 
 It does not claim that every possible future artifact already exists.
 It claims that the evidence that does exist is now navigable from a single public root.
-

--- a/evidence/artifact-0001/README.md
+++ b/evidence/artifact-0001/README.md
@@ -1,0 +1,10 @@
+# artifact-0001
+
+## Canonical artifact chain
+
+- **artifact-0006**
+- **artifact-0005**
+- **artifact-0004**
+- **artifact-0003**
+- **artifact-0002**
+- **artifact-0001**

--- a/evidence/artifact-0002-execution/README.md
+++ b/evidence/artifact-0002-execution/README.md
@@ -1,0 +1,10 @@
+# artifact-0002-execution
+
+## Canonical artifact chain
+
+- **artifact-0006**
+- **artifact-0005**
+- **artifact-0004**
+- **artifact-0003**
+- **artifact-0002**
+- **artifact-0001**

--- a/evidence/artifact-0002/README.md
+++ b/evidence/artifact-0002/README.md
@@ -1,0 +1,10 @@
+# artifact-0002
+
+## Canonical artifact chain
+
+- **artifact-0006**
+- **artifact-0005**
+- **artifact-0004**
+- **artifact-0003**
+- **artifact-0002**
+- **artifact-0001**

--- a/evidence/artifact-0003-reexecution/README.md
+++ b/evidence/artifact-0003-reexecution/README.md
@@ -1,0 +1,10 @@
+# artifact-0003-reexecution
+
+## Canonical artifact chain
+
+- **artifact-0006**
+- **artifact-0005**
+- **artifact-0004**
+- **artifact-0003**
+- **artifact-0002**
+- **artifact-0001**

--- a/evidence/artifact-0003/README.md
+++ b/evidence/artifact-0003/README.md
@@ -1,0 +1,10 @@
+# artifact-0003
+
+## Canonical artifact chain
+
+- **artifact-0006**
+- **artifact-0005**
+- **artifact-0004**
+- **artifact-0003**
+- **artifact-0002**
+- **artifact-0001**

--- a/evidence/artifact-0004/README.md
+++ b/evidence/artifact-0004/README.md
@@ -1,0 +1,10 @@
+# artifact-0004
+
+## Canonical artifact chain
+
+- **artifact-0006**
+- **artifact-0005**
+- **artifact-0004**
+- **artifact-0003**
+- **artifact-0002**
+- **artifact-0001**

--- a/evidence/artifact-0005/README.md
+++ b/evidence/artifact-0005/README.md
@@ -1,5 +1,15 @@
 # artifact-0005
 
+## Canonical artifact chain
+
+- **artifact-0006**
+- **artifact-0005**
+- **artifact-0004**
+- **artifact-0003**
+- **artifact-0002**
+- **artifact-0001**
+
+
 Subtitle: public canonical authority issuance and governed execution boundary
 
 ## Claim

--- a/evidence/artifact-0006/README.md
+++ b/evidence/artifact-0006/README.md
@@ -1,0 +1,30 @@
+# artifact-0006
+
+## Canonical role
+
+artifact-0006 materializes the terminal constitutional consequence layer of the Verifrax evidence perimeter.
+
+It binds:
+
+- **ANAGNORIUM** as terminal recognition
+- **REGRESSORIUM** as terminal recourse
+
+## Boundary
+
+artifact-0006 does not replace earlier evidence artifacts.
+
+It extends the chain beyond artifact-0005 and records the materialization of terminal recognition and terminal recourse as live bounded repository surfaces.
+
+## Linked repository surfaces
+
+- https://github.com/Verifrax/ANAGNORIUM
+- https://github.com/Verifrax/REGRESSORIUM
+
+## Canonical artifact chain
+
+- **artifact-0006**
+- **artifact-0005**
+- **artifact-0004**
+- **artifact-0003**
+- **artifact-0002**
+- **artifact-0001**

--- a/evidence/artifact-0006/artifact.json
+++ b/evidence/artifact-0006/artifact.json
@@ -1,0 +1,10 @@
+{
+  "artifact_id": "artifact-0006",
+  "title": "terminal constitutional consequence surface",
+  "status": "materialized",
+  "surfaces": {
+    "terminal_recognition": "https://github.com/Verifrax/ANAGNORIUM",
+    "terminal_recourse": "https://github.com/Verifrax/REGRESSORIUM"
+  },
+  "extends": "artifact-0005"
+}

--- a/evidence/artifact-execution-gap/README.md
+++ b/evidence/artifact-execution-gap/README.md
@@ -1,0 +1,10 @@
+# artifact-execution-gap
+
+## Canonical artifact chain
+
+- **artifact-0006**
+- **artifact-0005**
+- **artifact-0004**
+- **artifact-0003**
+- **artifact-0002**
+- **artifact-0001**

--- a/evidence/artifact-semantic-execution/README.md
+++ b/evidence/artifact-semantic-execution/README.md
@@ -1,0 +1,10 @@
+# artifact-semantic-execution
+
+## Canonical artifact chain
+
+- **artifact-0006**
+- **artifact-0005**
+- **artifact-0004**
+- **artifact-0003**
+- **artifact-0002**
+- **artifact-0001**

--- a/evidence/bootstrap-chain-status/README.md
+++ b/evidence/bootstrap-chain-status/README.md
@@ -1,0 +1,10 @@
+# bootstrap-chain-status
+
+## Canonical artifact chain
+
+- **artifact-0006**
+- **artifact-0005**
+- **artifact-0004**
+- **artifact-0003**
+- **artifact-0002**
+- **artifact-0001**

--- a/evidence/component-surface/README.md
+++ b/evidence/component-surface/README.md
@@ -1,0 +1,10 @@
+# component-surface
+
+## Canonical artifact chain
+
+- **artifact-0006**
+- **artifact-0005**
+- **artifact-0004**
+- **artifact-0003**
+- **artifact-0002**
+- **artifact-0001**

--- a/evidence/domain-surface/README.md
+++ b/evidence/domain-surface/README.md
@@ -1,0 +1,10 @@
+# domain-surface
+
+## Canonical artifact chain
+
+- **artifact-0006**
+- **artifact-0005**
+- **artifact-0004**
+- **artifact-0003**
+- **artifact-0002**
+- **artifact-0001**

--- a/evidence/package-surface/README.md
+++ b/evidence/package-surface/README.md
@@ -1,0 +1,10 @@
+# package-surface
+
+## Canonical artifact chain
+
+- **artifact-0006**
+- **artifact-0005**
+- **artifact-0004**
+- **artifact-0003**
+- **artifact-0002**
+- **artifact-0001**


### PR DESCRIPTION
This change materializes artifact-0006 in the evidence perimeter and elevates the canonical artifact chain across the evidence surface.

- adds artifact-0006
- updates the canonical artifact chain to 0006 -> 0001
- propagates the artifact chain across the evidence boundary