### PR TITLE
Align package pages to live GitHub Packages set

### DIFF
--- a/.github/workflows/identity.yml
+++ b/.github/workflows/identity.yml
@@ -20,5 +20,4 @@ jobs:
           HEADER=$(sed -n '/^```$/,/^```$/p' README.md | head -10)
           echo "$HEADER" | grep -q '^SYS-003$' || { echo "FAIL: SYS-003 not found"; exit 1; }
           echo "$HEADER" | grep -q '^STATUS: REGISTERED$' || { echo "FAIL: STATUS missing"; exit 1; }
-          echo "$HEADER" | grep -q '^REGISTRY: https://speedkit.eu$' || { echo "FAIL: REGISTRY missing"; exit 1; }
           echo "PASS: SYS-003 identity verified"

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ Repository: Verifrax/VERIFRAX
 ```
 SYS-003
 STATUS: REGISTERED
-REGISTRY: https://speedkit.eu
-SNAPSHOT: https://speedkit.eu/REGISTRY_SNAPSHOT.json
 ```
 
 ![License](https://img.shields.io/badge/license-Apache--2.0-blue)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VERIFRAX
 
-Package: @verifrax/root
+Package: @verifrax/verifrax
 Binary: verifrax-seal
 Repository: Verifrax/VERIFRAX
 

--- a/core/engine/verifier.ts
+++ b/core/engine/verifier.ts
@@ -72,7 +72,6 @@ function loadClaims(bundlePath: string): any[] {
   return claims;
 }
 
-
 /**
  * Main verification function
  * 

--- a/docs/ecosystem/CONFORMANCE_CERTIFICATION_PROCESS.md
+++ b/docs/ecosystem/CONFORMANCE_CERTIFICATION_PROCESS.md
@@ -107,6 +107,4 @@ verified implementation registry.
 Registry entry is a publication consequence of certification,
 not a substitute for certification.
 
-
-
 Active repository authority is defined by `AUTHORITY.md`. Maintained conformance suites are under `protocol-conformance/`, with the active suite root at `protocol-conformance/v2/`. Active maintained verifier implementations are `verifier/node` and `verifier/rust`. Active release freeze authority is defined by `release-integrity/freeze-surfaces.json`.

--- a/docs/ecosystem/ECOSYSTEM_GOVERNANCE_FUTURE_EVOLUTION.md
+++ b/docs/ecosystem/ECOSYSTEM_GOVERNANCE_FUTURE_EVOLUTION.md
@@ -144,8 +144,6 @@ The VERIFRAX ecosystem governance model allows future expansion
 without sacrificing deterministic verification, release integrity,
 or historical permanence.
 
-
-
 Active repository authority is defined by `AUTHORITY.md`. Maintained conformance suites are under `protocol-conformance/`, with the active suite root at `protocol-conformance/v2/`. Active maintained verifier implementations are `verifier/node` and `verifier/rust`. Active release freeze authority is defined by `release-integrity/freeze-surfaces.json`.
 
 ## Protocol Legitimacy Signals

--- a/docs/ecosystem/PROTOCOL_COMPLIANCE_BADGE_SYSTEM.md
+++ b/docs/ecosystem/PROTOCOL_COMPLIANCE_BADGE_SYSTEM.md
@@ -47,6 +47,4 @@ Any change in implementation state requires re-evaluation.
 The compliance badge system provides the public signaling layer
 for deterministic protocol conformance in the VERIFRAX ecosystem.
 
-
-
 Active repository authority is defined by `AUTHORITY.md`. Maintained conformance suites are under `protocol-conformance/`, with the active suite root at `protocol-conformance/v2/`. Active maintained verifier implementations are `verifier/node` and `verifier/rust`. Active release freeze authority is defined by `release-integrity/freeze-surfaces.json`.

--- a/docs/ecosystem/VERIFICATION_ARTIFACTS_INDEX.md
+++ b/docs/ecosystem/VERIFICATION_ARTIFACTS_INDEX.md
@@ -86,6 +86,4 @@ The index does not:
 The verification artifacts index is the canonical inventory of the
 artifacts that define and preserve VERIFRAX deterministic verification.
 
-
-
 Active repository authority is defined by `AUTHORITY.md`. Maintained conformance suites are under `protocol-conformance/`, with the active suite root at `protocol-conformance/v2/`. Active maintained verifier implementations are `verifier/node` and `verifier/rust`. Active release freeze authority is defined by `release-integrity/freeze-surfaces.json`.

--- a/docs/ecosystem/VERIFIED_IMPLEMENTATION_REGISTRY.md
+++ b/docs/ecosystem/VERIFIED_IMPLEMENTATION_REGISTRY.md
@@ -78,6 +78,4 @@ The registry does not:
 The verified implementation registry provides the public record of
 implementations that have demonstrated deterministic conformance to VERIFRAX.
 
-
-
 Active repository authority is defined by `AUTHORITY.md`. Maintained conformance suites are under `protocol-conformance/`, with the active suite root at `protocol-conformance/v2/`. Active maintained verifier implementations are `verifier/node` and `verifier/rust`. Active release freeze authority is defined by `release-integrity/freeze-surfaces.json`.

--- a/docs/protocol/AUTHORITATIVE_INDEX.md
+++ b/docs/protocol/AUTHORITATIVE_INDEX.md
@@ -26,7 +26,6 @@ VERIFRAX is the **authoritative source** for:
 |--------|--------------|
 | MK10-PRO | Upstream MTB definitions |
 | CICULLIS | Policy enforcement |
-| speedkit.eu | Discovery index |
 
 ## Non-authoritative
 

--- a/engine/originseal.sh
+++ b/engine/originseal.sh
@@ -25,7 +25,6 @@ TEXT="$(printf '%s' "$INPUT")"
 
 # --- Single-Seal Enforcement ----------------------------------------------
 
-
 # --- Origin Context --------------------------------------------------------
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"

--- a/evidence/README.md
+++ b/evidence/README.md
@@ -9,7 +9,6 @@
 - **artifact-0002**
 - **artifact-0001**
 
-
 This directory is the public evidence surface for VERIFRAX.
 
 It exists so that any reviewer, claimant, challenger, auditor, or adversarial reader can inspect what was asserted, what was executed, what was observed, what was not executable, and what boundary the current evidence actually proves.
@@ -219,7 +218,6 @@ Supporting examples:
 - `artifact-0003/authority-ledger-presence.txt`
 - `artifact-0003/seal-0001-presence.txt`
 - `artifact-0003/issued-object-search.txt`
-
 
 ### `artifact-0004/`
 

--- a/evidence/artifact-0005/README.md
+++ b/evidence/artifact-0005/README.md
@@ -9,7 +9,6 @@
 - **artifact-0002**
 - **artifact-0001**
 
-
 Subtitle: public canonical authority issuance and governed execution boundary
 
 ## Claim

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@verifrax/root",
-  "version": "0.0.0",
+  "name": "@verifrax/verifrax",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@verifrax/root",
-      "version": "0.0.0",
+      "name": "@verifrax/verifrax",
+      "version": "0.1.1",
       "dependencies": {
         "@sigstore/verify": "3.0.0"
       },
@@ -17,7 +17,8 @@
         "@types/node": "25",
         "@vercel/ncc": "^0.38.4",
         "typescript": "^5.9.3"
-      }
+      },
+      "private": false
     },
     "node_modules/@sigstore/bundle": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@verifrax/root",
+  "name": "@verifrax/verifrax",
   "private": false,
   "packageManager": "pnpm@9.0.0",
   "scripts": {
@@ -21,11 +21,11 @@
   "bin": {
     "verifrax-seal": "scripts/verifrax-seal.js"
   },
-  "version": "0.0.1",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Verifrax/VERIFRAX.git"
+    "url": "git+https://github.com/Verifrax/VERIFRAX.git"
   },
   "homepage": "https://github.com/Verifrax/VERIFRAX#readme",
   "bugs": {

--- a/public/deliver/CERTIFICATE_IMMUTABILITY.md
+++ b/public/deliver/CERTIFICATE_IMMUTABILITY.md
@@ -36,4 +36,3 @@ Third parties can verify certificates using:
 
 The certificate itself contains all necessary information for independent verification.
 
-

--- a/verifier/node/src/artifact/semantic-evaluator.mjs
+++ b/verifier/node/src/artifact/semantic-evaluator.mjs
@@ -197,7 +197,6 @@ function evaluateArtifact0003(repoRoot, artifact, artifactPath) {
   };
 }
 
-
 function evaluateArtifact0005(repoRoot, artifact, artifactPath) {
   const support = artifact.supporting_evidence || {};
 

--- a/verifier/rust/src/bin/semantic_evaluator.rs
+++ b/verifier/rust/src/bin/semantic_evaluator.rs
@@ -213,7 +213,6 @@ fn evaluate_artifact_0003(repo_root: &Path, artifact: &Value, artifact_path: &Pa
     }
 }
 
-
 fn evaluate_artifact_0005(repo_root: &Path, artifact: &Value, artifact_path: &Path) -> Value {
     let execution_status_path = resolve_evidence_path(repo_root, artifact_path, support_path(artifact, "execution_status"));
     let receipt_path = resolve_evidence_path(repo_root, artifact_path, support_path(artifact, "receipt_json"));


### PR DESCRIPTION
Align repo package pages to the live GitHub Packages set and remove package lines from repo-only pages.