### PR TITLE
Delete SPEEDKIT material from VERIFRAX and republish clean package

### DIFF
--- a/.github/workflows/identity.yml
+++ b/.github/workflows/identity.yml
@@ -20,5 +20,5 @@ jobs:
           HEADER=$(sed -n '/^```$/,/^```$/p' README.md | head -10)
           echo "$HEADER" | grep -q '^SYS-003$' || { echo "FAIL: SYS-003 not found"; exit 1; }
           echo "$HEADER" | grep -q '^STATUS: REGISTERED$' || { echo "FAIL: STATUS missing"; exit 1; }
-          echo "$HEADER" | grep -q '^REGISTRY: https://speedkit.eu$' || { echo "FAIL: REGISTRY missing"; exit 1; }
+          ! echo "$HEADER" | grep -q '^REGISTRY:' || { echo "FAIL: forbidden residue"; exit 1; }
           echo "PASS: SYS-003 identity verified"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,6 @@ jobs:
           subject-path: dist/verifrax-src.tar.gz
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@9d7e5d1ffb1dd2a7f6b1a552c43e8648bb2a5db3 # v2
+        uses: softprops/action-gh-release@v2 # v2
         with:
           files: dist/*

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ Repository: Verifrax/VERIFRAX
 ```
 SYS-003
 STATUS: REGISTERED
-REGISTRY: https://speedkit.eu
-SNAPSHOT: https://speedkit.eu/REGISTRY_SNAPSHOT.json
 ```
 
 ![License](https://img.shields.io/badge/license-Apache--2.0-blue)

--- a/docs/protocol/AUTHORITATIVE_INDEX.md
+++ b/docs/protocol/AUTHORITATIVE_INDEX.md
@@ -26,7 +26,6 @@ VERIFRAX is the **authoritative source** for:
 |--------|--------------|
 | MK10-PRO | Upstream MTB definitions |
 | CICULLIS | Policy enforcement |
-| speedkit.eu | Discovery index |
 
 ## Non-authoritative
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "@verifrax/root",
-  "version": "0.0.0",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@verifrax/root",
-      "version": "0.0.0",
+      "version": "0.0.2",
+      "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/verify": "3.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@verifrax/root",
-  "version": "0.0.2",
+  "name": "@verifrax/verifrax",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@verifrax/root",
-      "version": "0.0.2",
+      "name": "@verifrax/verifrax",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/verify": "3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@verifrax/verifrax",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@verifrax/verifrax",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/verify": "3.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "bin": {
     "verifrax-seal": "scripts/verifrax-seal.js"
   },
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@verifrax/root",
+  "name": "@verifrax/verifrax",
   "private": false,
   "packageManager": "pnpm@9.0.0",
   "scripts": {
@@ -21,11 +21,11 @@
   "bin": {
     "verifrax-seal": "scripts/verifrax-seal.js"
   },
-  "version": "0.0.2",
+  "version": "0.1.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Verifrax/VERIFRAX.git"
+    "url": "git+https://github.com/Verifrax/VERIFRAX.git"
   },
   "homepage": "https://github.com/Verifrax/VERIFRAX#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "bin": {
     "verifrax-seal": "scripts/verifrax-seal.js"
   },
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -33,5 +33,14 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "core",
+    "verifier",
+    "verifrax-engine",
+    "profiles",
+    "policy",
+    "README.md",
+    "LICENSE"
+  ]
 }


### PR DESCRIPTION
Delete SPEEDKIT-origin material from active VERIFRAX, advance the frozen source pointer, and republish a clean npm package.