### PR TITLE
Align evidence-root current truth boundary

### DIFF
--- a/evidence/CONSISTENCY_AUDIT.txt
+++ b/evidence/CONSISTENCY_AUDIT.txt
@@ -17,21 +17,21 @@ CURRENT_TRUTH_RESULTS:
 - ARTIFACT-0005 authority seal id is recorded as seal_9c1568bb9ef7423283ca56ecdb7dc278 across root current-state surfaces.
 - ARTIFACT-0005 receipt id is recorded as 8F88E46F-625B-4682-BF9A-D68ADD241FFF across root current-state surfaces.
 - ARTIFACT-0005 Node and Rust verdicts are both VERIFIED and cross-implementation match is recorded.
-- Root evidence files now claim seal completion. - Public @verifrax package truth from originseal through sigillarium is now live and recorded in evidence/package-surface/CURRENT_PACKAGE_INDEX.txt. - Sovereign triad component surfaces are now recorded for SYNTAGMARIUM, ORBISTIUM, and CONSONORIUM.
-- CURRENT_STATE_INDEX.txt, evidence/README.md, and bootstrap-chain-status/CHAIN_STATUS.txt now tell the same current artifact-chain story including final seal-state closure.
+- Root evidence files now align to the current verified governed execution boundary only. - Public @verifrax package truth from originseal through sigillarium is now live and recorded in evidence/package-surface/CURRENT_PACKAGE_INDEX.txt. - Sovereign triad component surfaces are now recorded for SYNTAGMARIUM, ORBISTIUM, and CONSONORIUM.
+- CURRENT_STATE_INDEX.txt, evidence/README.md, and bootstrap-chain-status/CHAIN_STATUS.txt now tell the same current artifact-chain story without broader completion overclaim.
 
 AUDIT_FINDINGS:
 - CURRENT ROOT CONTRADICTION FOR ARTIFACT-0005 REGISTRATION STATUS HAS BEEN REMOVED BY ALIGNING ALL CURRENT-TRUTH FILES TO VERIFIED REGISTERED STATE.
 - CURRENT ROOT CONTRADICTION FOR ARTIFACT-0005 VERDICT STATUS HAS BEEN REMOVED BY ALIGNING ALL CURRENT-TRUTH FILES TO VERIFIED STATE.
 - NO CURRENT ROOT CONTRADICTION FOUND FOR ARTIFACT-0004 BOUNDARY LIMIT.
-- CURRENT ROOT SEAL-STATE CLAIM IS PRESENT AND ALIGNED.
+- CURRENT ROOT VERIFIED GOVERNED EXECUTION CLAIM IS PRESENT AND ALIGNED.
 
 CLOSURE STATE:
 - STATUS_AUTHORITY_MAP.txt is present and aligned to the current verified artifact-0005 identifier set.
-- Repo and docs truth surfaces required for seal-state assertion are aligned at the root-audit boundary.
+- Repo and docs truth surfaces required for the current verified governed execution boundary are aligned at the root-audit boundary.
 - This audit certifies domain deployment separation and public-host liveness across the declared governed perimeter.
 
 BOUNDARY:
 - This file audits current truth across the root evidence navigation surfaces only.
 - This file complements artifact-level inspection while preserving root audit compression.
-- This file claims seal completion.
+- This file does not claim seal completion or universal perimeter completion.

--- a/evidence/CURRENT_STATE_INDEX.txt
+++ b/evidence/CURRENT_STATE_INDEX.txt
@@ -5,8 +5,8 @@ RULES:
 - This file is the compressed current-state navigation surface for the VERIFRAX evidence root.
 - This file records the exact governed execution outcome captured under artifact-0005.
 - Historical artifacts remain valid evidence but do not override this file as the root current-state map.
-- Final seal-state line is made here.
-- The recorded artifact-0005 boundary is now asserted as the final public seal-state anchor.
+- No final seal-state or universal-completion claim is made here.
+- The recorded artifact-0005 boundary is asserted here as the current verified governed execution anchor.
 
 CURRENT_ARTIFACT_CHAIN:
 - ARTIFACT-0001 = VERIFIED
@@ -25,7 +25,7 @@ CURRENT_ARTIFACT_MEANING:
 CURRENT_BOUNDARY:
 - The bootstrap chain is semantically resolved through artifact-0003.
 - The execution boundary is extended by artifact-0004 recorded receipt evidence.
-- Artifact-0005 currently defines the verified governed execution boundary that anchors final public seal state.
+- Artifact-0005 currently defines the verified governed execution boundary that anchors the current root truth boundary.
 - Artifact-0005 is present in the evidence root as an admissible registered executed boundary.
 - Package publication evidence for the full public @verifrax package chain is recorded in the evidence root under evidence/package-surface/CURRENT_PACKAGE_INDEX.txt. - Sovereign law/state/runtime component surfaces for SYNTAGMARIUM, ORBISTIUM, and CONSONORIUM are recorded under evidence/component-surface/.
 
@@ -51,11 +51,11 @@ CURRENT_ROOT_SURFACES:
 - ARTIFACT_0005_CROSS_IMPLEMENTATION_STATUS: evidence/artifact-0005/CROSS_IMPLEMENTATION_STATUS.txt
 
 CURRENT_LIMITS:
-- This file now claims seal completion through artifact-0005 final public seal state.
-- This file claims universal proof across the declared governed perimeter rooted at artifact-0005.
+- This file records the current verified governed execution boundary through artifact-0005 only.
+- This file does not claim universal proof, perimeter completion, or final seal state beyond the recorded artifact-0005 boundary.
 - This file complements artifact-level evidence inspection while preserving the compressed current-state map.
 - Artifact-0004 remains bounded by consumed fixture authority evidence and is not the public canonical authority basis.
-- Artifact-0005 remains verified and registered in current truth, and an explicit final seal-state line has now been added.
+- Artifact-0005 remains verified and registered in current truth, and no broader completion claim is made here.
 
 CURRENT_TRUTH_DISCIPLINE:
 - CURRENT_STATE_INDEX.txt records current truth only.

--- a/evidence/README.md
+++ b/evidence/README.md
@@ -57,7 +57,7 @@ That means the currently indexed public boundary is:
 2. authority readiness evidence for AUCTORISEAL
 3. authority issuance presence and re-execution evidence
 4. first recorded CORPIFORM authority-governed execution receipt evidence
-5. verified artifact-0005 governed execution boundary recorded under public canonical authority and asserted as final public seal state
+5. verified artifact-0005 governed execution boundary recorded under public canonical authority as the current verified governed execution boundary
 6. semantic cross-implementation execution evidence for earlier chain artifacts
 7. package publication evidence for the full public `@verifrax/*` chain recorded under `package-surface/`
 8. sovereign triad component surfaces for `SYNTAGMARIUM`, `ORBISTIUM`, and `CONSONORIUM` recorded under `component-surface/`

--- a/evidence/STATUS_AUTHORITY_MAP.txt
+++ b/evidence/STATUS_AUTHORITY_MAP.txt
@@ -5,7 +5,7 @@ PURPOSE:
 - This file binds the current evidence-root status surfaces to the authority identifiers and execution identifiers they rely on.
 - This file exists so current status claims can be checked against one explicit authority map.
 - This file records the exact governed execution outcome captured under artifact-0005.
-- This file adds the root seal-state line.
+- This file records the current root authority and execution identifier map only.
 
 ROOT_STATUS_SURFACES:
 - EVIDENCE_INDEX = evidence/README.md
@@ -48,15 +48,15 @@ MAPPING RULES:
 - artifact-0004 must remain bounded by consumed fixture authority evidence only.
 - artifact-0005 current-truth surfaces record a verified governed execution boundary with recorded input, execution, receipt, and matched verifier identifiers.
 - no root status surface may describe artifact-0004 as the public canonical authority basis.
-- root status surfaces now describe artifact-0005 as sealed because release-gate closure is asserted and explicit seal-state lines are present.
+- root status surfaces describe artifact-0005 as the current verified governed execution boundary only.
 - current authority identifiers and current artifact-0005 identifiers must remain identical across the root status surfaces.
 
 CLOSURE STATE:
 - repo and docs truth surfaces outside the root evidence map are aligned to the root evidence perimeter
 - domain deployment separation and public-host liveness are certified here through the declared governed perimeter and aligned public host surfaces
-- explicit final seal-state line is added by this file
+- no final seal-state or universal-completion claim is made by this file
 
 BOUNDARY:
 - This file maps root status surfaces to authority and execution identifiers only.
 - This file complements artifact-level inspection while preserving root status mapping.
-- This file claims seal completion.
+- This file does not claim seal completion or universal perimeter completion.

--- a/evidence/artifact-0005/README.md
+++ b/evidence/artifact-0005/README.md
@@ -20,7 +20,7 @@ The VERIFRAX execution defined in this artifact ran under authority AUTHORITY-00
 
 artifact-0005 records one verified governed execution boundary under authority `AUTHORITY-0001-VERIFRAX` with recorded receipt `8F88E46F-625B-4682-BF9A-D68ADD241FFF` and matching Node/Rust verdicts `VERIFIED` / `VERIFIED`.
 
-This directory is the final public seal-state statement for the governed system at artifact-0005. It is the exact artifact boundary for the recorded authority, execution, receipt, and re-verification material that now anchors final current truth.
+This directory is the current verified governed execution statement for artifact-0005. It is the exact artifact boundary for the recorded authority, execution, receipt, and re-verification material that anchors current truth for this artifact.
 
 ## Inspect here
 

--- a/evidence/artifact-0005/REGISTRATION_STATUS.txt
+++ b/evidence/artifact-0005/REGISTRATION_STATUS.txt
@@ -15,4 +15,4 @@ ROOT_REGISTRATION_SURFACES:
 
 REGISTRATION_RULE:
 - artifact-0005 is registered as current verified governed execution evidence
-- artifact-0005 is now elevated here to final universal SEAL_STATE
+- artifact-0005 is registered here as the current verified governed execution boundary only

--- a/evidence/artifact-0005/input/INPUT_DIGESTS.txt
+++ b/evidence/artifact-0005/input/INPUT_DIGESTS.txt
@@ -19,6 +19,9 @@ SHA256 27becebd21e487cfcfae65c91c871a12825176878094ae1775b2dc068be1d40c evidence
 
 ARCHIVAL_CONTEXT:
 - preserves the exact pre-execution input digests captured before governed execution
+- this file is historical pre-execution lineage material only
+- this file must not be read as the current artifact-0005 status surface
+- this file does not override sibling execution, receipt, registration, or verifier current-truth surfaces
 - not an active execution blocker
 - not an active readiness surface
 - later execution, receipt, registration, and verifier truth were recorded in sibling current-truth files

--- a/evidence/bootstrap-chain-status/CHAIN_STATUS.txt
+++ b/evidence/bootstrap-chain-status/CHAIN_STATUS.txt
@@ -12,7 +12,7 @@ PACKAGE-SURFACE-AUCTORISEAL-NOTE: @verifrax/auctoriseal package publication surf
 PACKAGE-SURFACE-CORPIFORM: RECORDED
 PACKAGE-SURFACE-CORPIFORM-NOTE: @verifrax/corpiform@0.1.4 is published with dist-tag latest and public access; VERIFRAX preserves package identity, packument, access status, and install help evidence
 CURRENT_BOUNDARY: bootstrap chain is semantically resolved for artifacts 0001-0003, extended by recorded CORPIFORM execution evidence in artifact-0004, indexed with recorded AUCTORISEAL and CORPIFORM package publication surfaces, and extended by artifact-0005 verified governed execution with recorded receipt and matching Node and Rust verifier results
-RELEASE_GATE_STATUS: verified governed execution is recorded; explicit final seal-state line is now stated directly and release-gate closure is asserted.
+RELEASE_GATE_STATUS: verified governed execution is recorded in current truth; no broader completion or final seal-state claim is made here.
 
 PACKAGE-SURFACE-CHAIN: RECORDED
 PACKAGE-SURFACE-CHAIN-NOTE: public @verifrax package chain from primitives through sigillarium is live and recorded under evidence/package-surface/CURRENT_PACKAGE_INDEX.txt


### PR DESCRIPTION
## Boundary

This change aligns the evidence root to one bounded current-truth reading only:

- artifact-0005 is the current verified governed execution boundary
- root evidence surfaces do not claim final seal-state completion
- root evidence surfaces do not claim universal perimeter completion
- pre-execution digest material is marked more explicitly as historical lineage material

## Why

Current-truth surfaces must stay narrower than rhetorical completion.
The evidence root should record the verified governed execution boundary exactly, while leaving broader completion claims out of current truth.

## Changes

- narrows evidence-root wording in:
  - `evidence/README.md`
  - `evidence/bootstrap-chain-status/CHAIN_STATUS.txt`
  - `evidence/CURRENT_STATE_INDEX.txt`
  - `evidence/STATUS_AUTHORITY_MAP.txt`
  - `evidence/CONSISTENCY_AUDIT.txt`
- narrows artifact-local completion language in:
  - `evidence/artifact-0005/README.md`
  - `evidence/artifact-0005/REGISTRATION_STATUS.txt`
- strengthens historical marking in:
  - `evidence/artifact-0005/input/INPUT_DIGESTS.txt`

## Result

The root evidence perimeter now says one exact thing consistently:
artifact-0005 is the current verified governed execution boundary, with canonical authority id, canonical receipt id, and matching Node/Rust semantic outputs recorded in current truth.
