### PR TITLE
Clarify VERIFRAX chamber boundary reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ VERIFRAX is the Verifrax authored protocol and evidence-root boundary: the publi
 
 ## Proof artifacts
 
-This repository is part of the VERIFRAX proof perimeter.
+This repository is part of the VERIFRAX governed protocol and evidence perimeter.
 
 - **ARTIFACT-0006**
 - **ARTIFACT-0005**
@@ -61,7 +61,7 @@ It does not serve as the public verifier UI.
 It does not serve as the seal/archive reference surface.
 It does not operate intake.
 It does not act as the commercial landing surface.
-It does not replace adjacent sovereign boundaries.
+It does not replace adjacent chamber boundaries or implementation strata.
 
 ## What it does
 
@@ -84,7 +84,7 @@ It does not replace adjacent sovereign boundaries.
 - not reconciliation or repair; that belongs to CONSONORIUM
 - not sovereign cognition; that belongs to TACHYRIUM
 
-## Adjacent sovereign surfaces
+## Adjacent chamber surfaces
 
 - `AUCTORISEAL` defines authority issuance
 - `CORPIFORM` defines governed execution
@@ -104,6 +104,39 @@ It does not publish proof as the proof surface.
 It does not act as the verifier UI.
 
 That separation must remain explicit.
+
+## Chamber stack vs implementation strata
+
+Read these as two different public classes:
+
+### Chambers
+
+- `SYNTAGMARIUM` — law
+- `ORBISTIUM` — state
+- `CONSONORIUM` — reconciliation
+- `TACHYRIUM` — cognition
+- `AUCTORISEAL` — authority
+- `CORPIFORM` — execution
+- `VERIFRAX` — verification
+- `ANAGNORIUM` — terminal recognition
+- `REGRESSORIUM` — terminal recourse
+
+### Implementation, host, and support strata
+
+- `VERIFRAX-WWW` — public root-host surface
+- `VERIFRAX-API` — API host implementation surface
+- `VERIFRAX-STATUS` — status host implementation surface
+- `VERIFRAX-SURFACE` — shared public-surface system
+- `VERIFRAX-SPEC` — derived specification publication
+- `VERIFRAX-DOCS` — explanatory documentation
+- `VERIFRAX-PROFILES` — deterministic profile-constraint surface
+- `VERIFRAX-verify` — public verification repository and UI boundary
+- `proof` — public proof publication surface
+- `SIGILLARIUM` — archive/reference surface
+- `apply` — intake surface
+
+These implementation, host, and support repositories are not parallel sovereignty.
+They must not be read as law, state, reconciliation, cognition, authority, execution, verification, terminal recognition, or terminal recourse merely because they are public-facing or operationally important.
 
 ## Authority and specification direction
 


### PR DESCRIPTION
## Boundary

This change sharpens the public reading of VERIFRAX itself.

It keeps VERIFRAX as the authored protocol and evidence-root verification boundary while making chamber repositories and implementation, host, and support repositories visibly non-interchangeable.

## Why

The public perimeter now needs the same reading discipline inside VERIFRAX that was just locked at the organization layer.

A cold reader must be able to distinguish:

- chamber repositories
- implementation, host, and support repositories

without inferring parallel sovereignty from public-facing surfaces.

## Changes

- changes VERIFRAX README from proof-perimeter wording to governed protocol and evidence perimeter wording
- narrows the non-replacement sentence to chamber boundaries and implementation strata
- changes `Adjacent sovereign surfaces` to `Adjacent chamber surfaces`
- adds an explicit `Chamber stack vs implementation strata` section

## Result

VERIFRAX now states one clearer perimeter reading:

- chamber stack: law, state, reconciliation, cognition, authority, execution, verification, terminal recognition, terminal recourse
- implementation, host, and support strata: WWW, API, STATUS, SURFACE, SPEC, DOCS, PROFILES, verify UI, proof publication, archive/reference, intake

This keeps public-facing implementation surfaces from being mistaken for chamber sovereignty while preserving VERIFRAX as authored protocol and evidence-root boundary.
