### PR TITLE
Align artifact-0005 registration boundary wording

### DIFF
--- a/evidence/artifact-0005/REGISTRATION_STATUS.txt
+++ b/evidence/artifact-0005/REGISTRATION_STATUS.txt
@@ -1,6 +1,6 @@
 ARTIFACT_ID: artifact-0005
 ARTIFACT_TITLE: public canonical authority issuance and governed execution boundary
-STATUS: REGISTERED IN ROOT EVIDENCE AS FINAL PUBLIC SEAL STATE
+STATUS: REGISTERED IN ROOT EVIDENCE AS VERIFIED GOVERNED EXECUTION BOUNDARY
 AUTHORITY_ID: AUTHORITY-0001-VERIFRAX
 RECEIPT_ID: 8F88E46F-625B-4682-BF9A-D68ADD241FFF
 NODE_VERDICT: VERIFIED
@@ -16,3 +16,7 @@ ROOT_REGISTRATION_SURFACES:
 REGISTRATION_RULE:
 - artifact-0005 is registered as current verified governed execution evidence
 - artifact-0005 is registered here as the current verified governed execution boundary only
+
+BOUNDARY:
+- this file records artifact-0005 root registration as current verified governed execution evidence only
+- this file does not claim final seal-state, universal completion, or release closure outside this artifact


### PR DESCRIPTION
## Boundary

This change narrows artifact-0005 registration wording only.

It does not change authority identity, receipt identity, verifier outcome, artifact-chain order, package truth, host truth, or chamber/perimeter role boundaries.

## Why

`evidence/artifact-0005/REGISTRATION_STATUS.txt` still used present-tense wording that overstated the artifact as a final public seal-state surface.

That wording conflicted with the active current-truth perimeter, which already limits artifact-0005 to a verified governed execution boundary and explicitly rejects broader final-seal or universal-completion claims.

## Change

- replace the stale final-seal-state registration line
- restate artifact-0005 as a verified governed execution boundary only
- add an explicit boundary block rejecting final seal-state, universal completion, and release-closure overclaim outside this artifact

## Result

artifact-0005 registration wording now matches the active current-truth spine and removes the remaining present-tense overclaim drift in Gate A.
