### PR TITLE
Clarify maintained verifier authority surfaces

### DIFF
--- a/docs/ecosystem/VERIFICATION_ARTIFACTS_INDEX.md
+++ b/docs/ecosystem/VERIFICATION_ARTIFACTS_INDEX.md
@@ -11,7 +11,7 @@ deterministic verification surface of the protocol.
 The verification artifacts index exists to identify:
 
 - official conformance artifacts
-- reference verifier implementations
+- maintained verifier implementations
 - integrity manifests
 - evidence bundles
 - verification transcripts
@@ -54,8 +54,8 @@ Repository content outside these functions is not part of the index scope.
 The initial index includes:
 
 - protocol-conformance
-- Node reference verifier
-- Rust minimal verifier
+- maintained Node verifier
+- maintained Rust verifier
 - verifier hash registry
 - release SHA256 manifest
 - genesis lineage

--- a/docs/protocol/ARTIFACT_CLASSIFICATION.md
+++ b/docs/protocol/ARTIFACT_CLASSIFICATION.md
@@ -1,252 +1,99 @@
 # VERIFRAX Artifact Classification
 
-**Purpose:** Classify all non-code artifacts into three buckets for access control.
+**Purpose:** classify repository artifacts by whether they are required for active verification authority, governance/context, or historical/internal preservation.
 
-**Rule:** Only bucket (1) remains public by default. Buckets (2) and (3) should be restricted.
-
----
-
-## (1) VERIFIABILITY-CRITICAL
-
-**Definition:** Artifacts required for independent verification of certificates and system behavior. These must remain public for verifiability.
-
-### Root Level
-- `README.md` - Main README (contains authority statements - verifiability-critical)
-- `AUTHORITATIVE_SCOPE.md` - Defines what is authoritative for verification
-- `AUTHORITY.md` - Authority boundaries (if exists)
-- `BUILD_ATTESTATION.md` - Build reproducibility requirements
-- `BUILD_HASH.txt` - Cryptographic build hash
-- `CERTIFICATE_CANONICAL_RULES.md` - Certificate format rules (critical for verification)
-- `CANONICAL_HASHES_v1.txt` - Canonical hash registry
-- `EVIDENCE_FINALITY.md` - Evidence immutability rules
-- `EVIDENCE_PACKAGE_FORMAT.md` - Evidence bundle format specification
-- `IMMUTABILITY_SEAL_v1.txt` - Immutability proof
-- `SYSTEM_IDENTITY.json` - System identity declaration
-- `SYSTEM_IDENTITY.txt` - System identity declaration
-- `SCOPE_HASH.txt` - Scope hash
-- `SCRIPTS_HASHES_v1.txt` - Script hashes for reproducibility
-- `SURVIVAL_ARCHIVE_HASH.txt` - Archive hash
-- `VERSION.txt` - Version identifier
-- `build.provenance.json` - Build provenance data
-
-### Freeze Directory
-- `freeze/v2.6.0/` - All files (frozen artifacts)
-- `freeze/v2.5.0/` - All files (frozen artifacts)
-- `freeze/v2.4.0/` - All files (frozen artifacts)
-- `freeze/v2.3.0/` - All files (frozen artifacts)
-- `freeze/v2/` - All files (frozen artifacts)
-- `freeze/certificate.v1.json` - Certificate template
-- `freeze/core.dist.hash` - Core distribution hash
-- `freeze/ENGINE.json` - Engine specification
-
-### Documentation (Specifications Only)
-- `docs/EVIDENCE_BUNDLE_SPEC_v1.md` - Evidence bundle specification
-- `docs/DNS_AUDIT_v2.md` - DNS audit specification (if verification-critical)
-- `docs/V2_EDGE_API.md` - API specification for verification
-- `docs/V2_VERIFY_API.md` - Verification API specification
-- `docs/GOVERNANCE_DISPUTE_FINALITY.md` - Dispute finality rules (verification-critical)
-- `docs/GOVERNANCE_VERSION_FINALITY.md` - Version finality rules (verification-critical)
-- `docs/PRICING_RISK_TIERS.md` - Pricing tiers (if affects verification outcomes)
-
-### Index Directory
-- `index/` - All files (verification index)
-
-### Public Directory (Verification Artifacts)
-- `public/CANONICAL_HASHES_v1.txt` - Public canonical hashes
-- `public/IMMUTABILITY_SEAL_v1.txt` - Public immutability seal
-- `public/robots.txt` - Public access rules
-- `public/index.txt` - Public index
-- `public/verify/index.txt` - Verification endpoint index
-- `public/status/index.txt` - Status endpoint index
-- `public/conformance/golden/` - Conformance test data (verification-critical)
-
-### Reference Verifier
-- `verifrax-reference-verifier/REFERENCE_AUTHORITY.md` - Reference verifier authority
-- `verifrax-reference-verifier/README.md` - Reference verifier documentation (verifiability-critical)
-- `verifrax-verifier-min/README.md` - Minimal verifier documentation (verifiability-critical)
-
-### Product (Specifications Only)
-- `product/delivery/DELIVERY_CERTIFICATE_SPEC.md` - Delivery certificate specification
-- `product/delivery/DELIVERY_CERTIFICATE_SKU.md` - Delivery certificate SKU (if verification-critical)
-
-### Examples
-- `examples/real-world-certificate/` - Real certificate examples (verification-critical)
+**Interpretation rule:** active repository authority is defined by `AUTHORITY.md`. If this classification and `AUTHORITY.md` appear to differ, `AUTHORITY.md` prevails.
 
 ---
 
-## (2) GOVERNANCE/META
+## (1) ACTIVE VERIFICATION AUTHORITY
 
-**Definition:** Governance documents, policies, legal positions, terms, and organizational metadata. These define how the system is governed but are not required for verification.
+**Definition:** artifacts that belong to the currently maintained repository authority path for normative protocol interpretation, maintained verifier execution, conformance, release-integrity, registry, and deterministic audit navigation.
 
-### Root Level
-- `GOVERNANCE.md` - System governance
-- `VERSION_GOVERNANCE_AND_CHANGE_CONTROL.md` - Version governance policy
-- `LEGAL_POSITION.md` - Legal position statement
-- `TERMS.md` - Terms of service
-- `PRIVACY.md` - Privacy policy
-- `SECURITY.md` - Security policy
-- `LICENSE` - License file
-- `ISSUE_PR_POLICY.md` - Issue/PR policy
-- `ORG_README.md` - Organization README
-- `ORG_PINNED_REPOSITORIES.md` - Organization repository list
-- `POSITION.md` - Position statement
-- `POSITION_ON_STANDARDS.md` - Standards position
-- `STANDARD_COMPATIBILITY.md` - Standards compatibility statement
-- `FAQ_EXTERNAL.md` - External FAQ
-- `PUBLIC_EXPLAINER.md` - Public explanation (meta, not verification-critical)
+### Canonical active roots
 
-### Product (Governance)
-- `product/legal/TERMS_OF_VERIFICATION.md` - Terms of verification
-- `product/legal/LIMITATION_OF_LIABILITY.md` - Liability limitation
-- `product/legal/JURISDICTION.md` - Jurisdiction statement
-- `product/legal/ARTIFACT_LICENSE.md` - Artifact license
-- `product/governance/PAYMENT_FINALITY_BINDING.md` - Payment finality governance
-- `product/pricing/OUTCOME_PRICING.md` - Pricing policy
-- `product/status/OPERATIONAL_TRUTH.md` - Operational status (governance)
-- `product/VERSION.md` - Product version (governance)
-- `product/SYSTEM_SURFACE_MANIFEST.md` - System surface manifest (governance)
+- `AUTHORITY.md`
+- `docs/spec/`
+- `protocol-conformance/`
+- `verifier/node/`
+- `verifier/rust/`
+- `release-integrity/`
+- `registry/`
+- `index/`
 
-### Documentation (Non-Spec)
-- `docs/README.md` - Documentation README
-- `docs/index.html` - Documentation index
+### Active verification-result and evidence-root surfaces
 
-### Releases
-- `releases/RELEASE_v2.4.0.md` - Release notes (governance)
+- `verification/results/current/`
+- `verification/results/history/`
+- `evidence/`
+- `README.md` when used to state the current repository boundary and public-role separation
 
-### Public Directory (Non-Verification)
-- `public/legal/index.txt` - Legal index
-- `public/pricing/index.txt` - Pricing index
-- `public/docs/index.txt` - Documentation index
-- `public/deliver/index.txt` - Delivery index
+### Active maintained-verifier statements
 
-### Reference Verifier (Non-Authority)
-- `verifrax-reference-verifier/LEGAL_USAGE.md` - Legal usage guidelines
-- `verifrax-reference-verifier/VERIFY_WITHOUT_VERIFRAX.md` - Usage guide (non-authority)
-
-### Examples (Non-Critical)
-- `examples/README.md` - Examples README
-
-### Mappings/Profiles (Authority Docs)
-- `VERIFRAX-MAPPINGS-README.md` - Mappings README
-- `VERIFRAX-PROFILES-AUTHORITY.md` - Profiles authority
-- `VERIFRAX-PROFILES-README.md` - Profiles README
-- `VERIFRAX-SPEC-AUTHORITY.md` - Spec authority
-- `VERIFRAX-SPEC-README.md` - Spec README
+- any document that explicitly names `verifier/node` and `verifier/rust` as the only maintained verifier surfaces
+- conformance and release-integrity material that resolves through active maintained verifier paths
 
 ---
 
-## (3) INTERNAL DOCTRINE / CONTINGENCY
+## (2) GOVERNANCE / EXPLANATORY / SUPPORT
 
-**Definition:** Internal defensive documents, contingency plans, dissolution scenarios, and operational doctrine. These are internal planning documents.
+**Definition:** artifacts that help readers, implementers, auditors, or operators understand the repository, but do not themselves outrank the active authority path.
 
-### Root Level
-- `ADVERSARIAL_AUDIT_DEFENSE.md` - Adversarial audit defense
-- `AUTHORITY_CLOSURE_CERTIFICATE.md` - Authority closure certificate
-- `AUDITOR_ENTRY.md` - Auditor entry guide
-- `CHAIN_OF_CUSTODY_NOTE.md` - Chain of custody documentation
-- `CI_LANGUAGE_CHECK.md` - CI language check (internal)
-- `CLOUDFLARE_AUDIT_v2.4.0.md` - Cloudflare audit (internal)
-- `COMPANY_DISSOLUTION.md` - Company dissolution plan
-- `CRYPTO_INDEPENDENCE.md` - Cryptographic independence statement
-- `DISAPPEARANCE_TEST.md` - Disappearance test scenario
-- `DOMAIN_FAILURE.md` - Domain failure contingency
-- `END_STATE_ASSERTION.md` - End state assertion
-- `EXECUTION_SECRECY_VERIFICATION.md` - Execution secrecy verification
-- `EXTERNAL_SIGNAL_CHECK.md` - External signal check
-- `FINAL_TAG_ARCHIVE.md` - Final tag archive documentation
-- `FREEZE_NOTICE.md` - Freeze notice
-- `FREEZE_NOTICE.txt` - Freeze notice (text)
-- `HOW_TO_REIMPLEMENT_VERIFRAX.md` - Reimplementation guide
-- `MAINTAINER_ABSENCE.md` - Maintainer absence plan
-- `MISINTERPRETATION_DEFENSE.md` - Misinterpretation defense
-- `PAYMENT_AND_VALUE_BOUNDARY.md` - Payment boundary definition
-- `PAYMENT_EXECUTION_BOUNDARY.md` - Payment execution boundary
-- `PDF_EXPORT_RULES.md` - PDF export rules (internal)
-- `PHASE3_FREEZE_CONFIRMATION.md` - Phase 3 freeze confirmation
-- `PHASE7_END_STATE.md` - Phase 7 end state
-- `PHASE8_END_STATE.md` - Phase 8 end state
-- `PHASE9_END_STATE.md` - Phase 9 end state
-- `POST_VERIFRAX_WORLD.md` - Post-VERIFRAX world planning
-- `RECONSTRUCT_VERIFICATION.md` - Verification reconstruction guide
-- `REGULATED_BUSINESS_DEFENSE.md` - Regulated business defense
-- `REPO_AUDIT_CHECKLIST.md` - Repository audit checklist
-- `STRIPE_FINAL_DEFENSIVE.md` - Stripe defensive posture
-- `STRIPE_PRODUCT_DEFINITION.md` - Stripe product definition
-- `STRIPE_REVIEW_TEXT.md` - Stripe review text
-- `VALIDATION_REPORT_v2.4.0.md` - Validation report (internal)
-- `ENVIRONMENT_FINGERPRINT.txt` - Environment fingerprint (internal)
+Examples include:
 
-### Documentation (Internal)
-- `docs/_graveyard/` - All files (archived/internal)
-- `docs/external-anchors/` - External anchor content (internal strategy)
+- `docs/ecosystem/`
+- explanatory READMEs outside canonical active roots
+- governance notes
+- compatibility notes
+- process documentation
+- reproduction instructions
+- release explanations
+- host/repo separation guidance
 
-### Product (Internal)
-- `product/delivery/WORKED_SCENARIO_MEDIA_DELIVERY.md` - Worked scenario (internal)
-
-### Operations
-- `ops/` - All files (operational/internal)
-
-### Archive
-- `archive/` - All files (historical/internal)
-
-### Freeze (Internal Documentation)
-- `freeze/v2.8.0/` - Internal freeze documentation
-
-### Design Documents
-- `VERIFRAX-v2.5.0-design/` - All files (design/internal)
-
-### Scripts (Internal)
-- `scripts/` - All files (internal scripts)
-- `complete-certificate-issuance.sh` - Internal script
-- `final-anchor-execution.sh` - Internal script
-- `final-issuance-pipeline.sh` - Internal script
-
-### CI
-- `ci/` - All files (internal CI)
-
-### Terminal Authority
-- `terminal_authority.asc` - Terminal authority (internal)
-
-### Manifest
-- `manifest.json` - Manifest (internal)
-
-### Workspace
-- `VERIFRAX.code-workspace` - Workspace file (internal)
-
-### Archives
-- `VERIFRAX_v2.7.0_SURVIVAL_ARCHIVE.tar.gz` - Survival archive (internal)
-- `exhibit.tar.gz` - Exhibit archive (internal)
-
-### Public (Internal Samples)
-- `public/sample-certificate/` - Sample certificate (internal)
-
-### Reference Verifier (Internal)
-- `verifrax-reference-verifier/WHY_VERIFRAX_CANNOT_CHEAT.md` - Internal explanation
+These materials may explain active surfaces, but they do not replace them.
 
 ---
 
-## Classification Summary
+## (3) HISTORICAL / ARCHIVE / INTERNAL
 
-| Bucket | Count Estimate | Public by Default |
-|--------|---------------|-------------------|
-| (1) Verifiability-Critical | ~50-70 files | ✅ YES |
-| (2) Governance/Meta | ~40-60 files | ❌ NO |
-| (3) Internal Doctrine/Contingency | ~100-150 files | ❌ NO |
+**Definition:** artifacts preserved for lineage, audit continuity, historical re-reading, or internal doctrine that must not be interpreted as current maintained repository authority.
 
----
+Includes:
 
-## Notes
-
-- **Frozen artifacts** in `freeze/` directories are always verifiability-critical
-- **Specifications** that define formats, APIs, or verification procedures are verifiability-critical
-- **Hash files** and cryptographic artifacts are verifiability-critical
-- **Legal/terms** documents are governance/meta
-- **Defensive/contingency** documents are internal doctrine
-- **Design documents** and **archives** are internal doctrine
-- **Operational scripts** and **CI** are internal doctrine
+- `archive/`
+- `release-history/`
+- superseded verifier-era directories and references
+- frozen historical snapshots
+- generated outputs
+- temporary build material
+- internal doctrine, contingency, or planning material
+- `node_modules/`, local caches, and tool output
+- archived verifier names such as `verifrax-reference-verifier` and `verifrax-verifier-min` when preserved only for history
 
 ---
 
-**Last Updated:** Classification created for artifact access control
-**Status:** Complete classification of all non-code artifacts
+## Hard rule
 
+Historical or archived verifier material must never be read as current maintained verifier authority.
+
+The only active maintained verifier directories are:
+
+- `verifier/node`
+- `verifier/rust`
+
+---
+
+## Summary
+
+For active repository interpretation, use:
+
+- `AUTHORITY.md`
+- `docs/spec/`
+- `protocol-conformance/`
+- `release-integrity/`
+- `registry/`
+- `index/`
+- `verifier/node`
+- `verifier/rust`
+
+Anything outside that active path is explanatory, historical, or internal unless explicitly re-designated by a canonical active surface.

--- a/docs/protocol/AUTHORITATIVE_INDEX.md
+++ b/docs/protocol/AUTHORITATIVE_INDEX.md
@@ -2,48 +2,52 @@
 
 ## This repository
 
-VERIFRAX is the **authoritative source** for:
-- Evidence bundle verification
-- Certificate generation
-- Verification engine logic
-- Certificate schema
+VERIFRAX is the authoritative repository boundary for:
 
-## Authoritative files
+- normative protocol specification under `docs/spec/`
+- maintained conformance under `protocol-conformance/`
+- maintained verifier implementations under `verifier/`
+- active release-integrity metadata under `release-integrity/`
+- registry and index surfaces used for deterministic repository interpretation
 
-| File | Authority |
+Repository authority must be read through `AUTHORITY.md`.
+
+## Canonical active surfaces
+
+| Surface | Authority |
 |------|-----------|
-| `verifrax-engine/execute_v2_6_0.js` | Execution engine |
-| `verifrax-reference-verifier/` | Offline verification |
-| `verifrax-freeze/` | Frozen snapshots |
-| `CERTIFICATE_SCHEMA.json` | Certificate structure |
-| `AUTHORITATIVE_SCOPE.md` | Authority boundaries |
-| `CANONICAL.md` | Scope and purpose |
-| `ADVERSARIAL_FAQ.md` | Misinterpretation corrections |
+| `AUTHORITY.md` | repository authority map |
+| `docs/spec/` | normative protocol semantics |
+| `protocol-conformance/` | maintained conformance authority |
+| `verifier/node` | maintained Node verifier |
+| `verifier/rust` | maintained Rust verifier |
+| `release-integrity/` | active release-integrity authority |
+| `registry/` | maintained registry declarations |
+| `index/` | maintained repository index surfaces |
 
-## Related systems
+## Historical and non-authority surfaces
 
-| System | Relationship |
-|--------|--------------|
-| MK10-PRO | Upstream MTB definitions |
-| CICULLIS | Policy enforcement |
+The following are not active repository authority unless a canonical active surface explicitly re-designates them:
 
-## Non-authoritative
+- `archive/`
+- `release-history/`
+- superseded verifier-era directories
+- frozen historical snapshots retained for lineage
+- generated outputs
+- explanatory prose outside declared active authority surfaces
 
-- `docs/` (informational only)
-- docs layer
-- Marketing text
-- README prose
+## Maintained verifier rule
+
+The only active maintained verifier directories in this repository are:
+
+- `verifier/node`
+- `verifier/rust`
+
+Archived or historical verifier material must not be treated as current implementation authority.
 
 ## Verification
 
 ```bash
-# Verify build hashes
-./BUILD_REPRODUCE.sh
-
-# Verify certificate against schema
-# (requires JSON schema validator)
+./docs/operations/BUILD_REPRODUCE.sh
 ```
 
-## Live endpoint
-
-https://api.verifrax.net — Production execution


### PR DESCRIPTION
## Summary

Clarifies the active maintained verifier authority path so the repository no longer allows archived or historical verifier naming to compete with current maintained surfaces.

## What changed

- rewrote `docs/protocol/AUTHORITATIVE_INDEX.md` around the active authority path
- reclassified `docs/protocol/ARTIFACT_CLASSIFICATION.md` around active, explanatory, and historical material
- replaced outdated verifier wording in `docs/ecosystem/VERIFICATION_ARTIFACTS_INDEX.md`

## Authority alignment

This change makes the maintained verifier rule explicit:

- `verifier/node`
- `verifier/rust`

Historical or archived verifier material remains historical unless a canonical active surface explicitly re-designates it.

## Validation

- collision wording audit passed
- maintained verifier wording audit passed
- branch pushed to origin at commit `f6c25da`
