### PR TITLE
Add VERIFRAX current cross-stack chain bundle and replay schema

### DIFF
--- a/evidence/CURRENT_STATE_INDEX.txt
+++ b/evidence/CURRENT_STATE_INDEX.txt
@@ -44,6 +44,8 @@ CURRENT_ARTIFACT_0005_BINDING:
 - CANONICAL_SEMANTIC_SHA256: 801c87f08221ac194282b1a2e7f58cac2dcc143f6944c98a888edc086a72fc6b
 - VERIFICATION_RESULT_ID: verification-result-0001
 - VERIFICATION_RESULT_OBJECT: verification/results/current/verification-result-0001.json
+- CROSS_STACK_CHAIN_BUNDLE: evidence/chain/current/cross-stack-chain-bundle-0001.json
+- CROSS_STACK_CHAIN_INDEX: evidence/chain/current/index.json
 
 CURRENT_ROOT_SURFACES:
 - EVIDENCE_INDEX: evidence/README.md

--- a/evidence/README.md
+++ b/evidence/README.md
@@ -16,6 +16,8 @@ It exists so that any reviewer, claimant, challenger, auditor, or adversarial re
 
 This index is not a substitute for the evidence objects themselves. It is the canonical navigation surface for those objects.
 
+The current machine-readable cross-stack binding object is published at `chain/current/cross-stack-chain-bundle-0001.json` with index `chain/current/index.json`.
+
 ---
 
 ## Current boundary

--- a/evidence/STATUS_AUTHORITY_MAP.txt
+++ b/evidence/STATUS_AUTHORITY_MAP.txt
@@ -12,6 +12,8 @@ ROOT_STATUS_SURFACES:
 - CHAIN_STATUS = evidence/bootstrap-chain-status/CHAIN_STATUS.txt
 - CURRENT_STATE_INDEX = evidence/CURRENT_STATE_INDEX.txt
 - CONSISTENCY_AUDIT = evidence/CONSISTENCY_AUDIT.txt
+- CROSS_STACK_CHAIN_BUNDLE = evidence/chain/current/cross-stack-chain-bundle-0001.json
+- CROSS_STACK_CHAIN_INDEX = evidence/chain/current/index.json
 
 CURRENT_AUTHORITY_ROOT:
 - GOVERNANCE_ROOT = github.com/Verifrax/.github

--- a/evidence/chain/current/cross-stack-chain-bundle-0001.json
+++ b/evidence/chain/current/cross-stack-chain-bundle-0001.json
@@ -1,0 +1,62 @@
+{
+  "object_type": "CrossStackChainBundle",
+  "chain_bundle_id": "cross-stack-chain-bundle-0001",
+  "status": "ACTIVE_TRUTH",
+  "subject_artifact_id": "artifact-0005",
+  "subject_ref": "evidence/artifact-0005/artifact-0005.json",
+  "execution_subject_ref": "github.com/Verifrax/CORPIFORM",
+  "claim_class_refs": {
+    "verification_result": "https://github.com/Verifrax/SYNTAGMARIUM/blob/main/claim-classes/verification-result.json",
+    "recognition_object": "https://github.com/Verifrax/SYNTAGMARIUM/blob/main/claim-classes/recognition-object.json",
+    "recourse_object": "https://github.com/Verifrax/SYNTAGMARIUM/blob/main/claim-classes/recourse-object.json"
+  },
+  "governing_refs": {
+    "law_version": "https://github.com/Verifrax/SYNTAGMARIUM/blob/main/law/versions/current/law-version-0001.json",
+    "freeze_object": "https://github.com/Verifrax/SYNTAGMARIUM/blob/main/freeze/objects/current/freeze-object-0001.json",
+    "accepted_epoch": "https://github.com/Verifrax/ORBISTIUM/blob/main/epochs/current/accepted-epoch-0001.json",
+    "authority_object": "https://github.com/Verifrax/AUCTORISEAL/blob/main/authorities/current/authority-object-0001.json",
+    "execution_receipt": "https://github.com/Verifrax/CORPIFORM/blob/main/receipts/current/execution-receipt-0001.json",
+    "verification_result": "verification/results/current/verification-result-0001.json",
+    "recognition_object": "https://github.com/Verifrax/ANAGNORIUM/blob/main/recognitions/current/recognition-object-0001.json",
+    "recourse_object": "https://github.com/Verifrax/REGRESSORIUM/blob/main/claims/current/recourse-object-0001.json"
+  },
+  "index_refs": {
+    "chain_index": "evidence/chain/current/index.json",
+    "recognition_index": "https://github.com/Verifrax/ANAGNORIUM/blob/main/recognitions/current/index.json",
+    "recourse_index": "https://github.com/Verifrax/REGRESSORIUM/blob/main/claims/current/index.json",
+    "historical_archive": "evidence/chain/history/"
+  },
+  "binding_summary": {
+    "authority_id": "AUTHORITY-0001-VERIFRAX",
+    "authority_seal_id": "seal_9c1568bb9ef7423283ca56ecdb7dc278",
+    "receipt_id": "8F88E46F-625B-4682-BF9A-D68ADD241FFF",
+    "verification_result_id": "verification-result-0001",
+    "recognition_object_id": "recognition-object-0001",
+    "recourse_object_id": "recourse-object-0001",
+    "node_verdict": "VERIFIED",
+    "rust_verdict": "VERIFIED",
+    "cross_implementation_match": "MATCH",
+    "canonical_semantic_sha256": "801c87f08221ac194282b1a2e7f58cac2dcc143f6944c98a888edc086a72fc6b"
+  },
+  "consistency": {
+    "law_version_match": true,
+    "accepted_epoch_match": true,
+    "authority_object_match": true,
+    "execution_receipt_match": true,
+    "verification_result_match": true,
+    "subject_ref_match": true,
+    "recognition_index_binding_ok": true,
+    "recourse_index_binding_ok": true,
+    "recognition_precedes_recourse": true
+  },
+  "limits": [
+    "this bundle records current cross-stack binding for artifact-0005 only",
+    "this bundle does not replace law objects, accepted epoch objects, authority issuance objects, execution receipts, verification results, recognition objects, or recourse objects",
+    "historical chain bundles must remain under evidence/chain/history/ and may not outrank this active bundle",
+    "this bundle is a machine-readable replay pointer surface, not a substitute for the underlying chamber objects"
+  ],
+  "notes": [
+    "This object publishes the active cross-stack object chain for the current verified artifact-0005 boundary.",
+    "Its role is to let an outsider trace claim class, governing law, freeze, epoch, authority, receipt, verification, recognition, and recourse without founder narration."
+  ]
+}

--- a/evidence/chain/current/index.json
+++ b/evidence/chain/current/index.json
@@ -1,0 +1,16 @@
+{
+  "object_type": "CrossStackChainIndex",
+  "status": "ACTIVE_TRUTH",
+  "historical": false,
+  "current_chain_bundle_ref": "evidence/chain/current/cross-stack-chain-bundle-0001.json",
+  "entries": [
+    {
+      "chain_bundle_id": "cross-stack-chain-bundle-0001",
+      "path": "evidence/chain/current/cross-stack-chain-bundle-0001.json",
+      "subject_artifact_id": "artifact-0005",
+      "verification_result_id": "verification-result-0001",
+      "recognition_object_id": "recognition-object-0001",
+      "recourse_object_id": "recourse-object-0001"
+    }
+  ]
+}

--- a/evidence/chain/history/README.md
+++ b/evidence/chain/history/README.md
@@ -1,0 +1,7 @@
+# Historical cross-stack chain bundles
+
+This directory preserves superseded or historical cross-stack chain bundles only.
+
+Historical chain bundles remain auditable and reconstructable.
+
+They must not outrank the current active bundle published under `evidence/chain/current/`.

--- a/schemas/cross-stack-chain-bundle.schema.json
+++ b/schemas/cross-stack-chain-bundle.schema.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Verifrax/VERIFRAX/blob/main/schemas/cross-stack-chain-bundle.schema.json",
+  "title": "VERIFRAX Cross-Stack Chain Bundle",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "object_type",
+    "chain_bundle_id",
+    "status",
+    "subject_artifact_id",
+    "subject_ref",
+    "execution_subject_ref",
+    "claim_class_refs",
+    "governing_refs",
+    "index_refs",
+    "binding_summary",
+    "consistency",
+    "limits",
+    "notes"
+  ],
+  "properties": {
+    "object_type": { "const": "CrossStackChainBundle" },
+    "chain_bundle_id": { "type": "string", "minLength": 1 },
+    "status": { "const": "ACTIVE_TRUTH" },
+    "subject_artifact_id": { "const": "artifact-0005" },
+    "subject_ref": { "type": "string", "minLength": 1 },
+    "execution_subject_ref": { "type": "string", "minLength": 1 },
+    "claim_class_refs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "verification_result",
+        "recognition_object",
+        "recourse_object"
+      ],
+      "properties": {
+        "verification_result": { "type": "string", "minLength": 1 },
+        "recognition_object": { "type": "string", "minLength": 1 },
+        "recourse_object": { "type": "string", "minLength": 1 }
+      }
+    },
+    "governing_refs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "law_version",
+        "freeze_object",
+        "accepted_epoch",
+        "authority_object",
+        "execution_receipt",
+        "verification_result",
+        "recognition_object",
+        "recourse_object"
+      ],
+      "properties": {
+        "law_version": { "type": "string", "minLength": 1 },
+        "freeze_object": { "type": "string", "minLength": 1 },
+        "accepted_epoch": { "type": "string", "minLength": 1 },
+        "authority_object": { "type": "string", "minLength": 1 },
+        "execution_receipt": { "type": "string", "minLength": 1 },
+        "verification_result": { "type": "string", "minLength": 1 },
+        "recognition_object": { "type": "string", "minLength": 1 },
+        "recourse_object": { "type": "string", "minLength": 1 }
+      }
+    },
+    "index_refs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "chain_index",
+        "recognition_index",
+        "recourse_index",
+        "historical_archive"
+      ],
+      "properties": {
+        "chain_index": { "type": "string", "minLength": 1 },
+        "recognition_index": { "type": "string", "minLength": 1 },
+        "recourse_index": { "type": "string", "minLength": 1 },
+        "historical_archive": { "type": "string", "minLength": 1 }
+      }
+    },
+    "binding_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_id",
+        "authority_seal_id",
+        "receipt_id",
+        "verification_result_id",
+        "recognition_object_id",
+        "recourse_object_id",
+        "node_verdict",
+        "rust_verdict",
+        "cross_implementation_match",
+        "canonical_semantic_sha256"
+      ],
+      "properties": {
+        "authority_id": { "type": "string", "minLength": 1 },
+        "authority_seal_id": { "type": "string", "minLength": 1 },
+        "receipt_id": { "type": "string", "minLength": 1 },
+        "verification_result_id": { "type": "string", "minLength": 1 },
+        "recognition_object_id": { "type": "string", "minLength": 1 },
+        "recourse_object_id": { "type": "string", "minLength": 1 },
+        "node_verdict": { "type": "string", "minLength": 1 },
+        "rust_verdict": { "type": "string", "minLength": 1 },
+        "cross_implementation_match": { "type": "string", "minLength": 1 },
+        "canonical_semantic_sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "consistency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "law_version_match",
+        "accepted_epoch_match",
+        "authority_object_match",
+        "execution_receipt_match",
+        "verification_result_match",
+        "subject_ref_match",
+        "recognition_index_binding_ok",
+        "recourse_index_binding_ok",
+        "recognition_precedes_recourse"
+      ],
+      "properties": {
+        "law_version_match": { "const": true },
+        "accepted_epoch_match": { "const": true },
+        "authority_object_match": { "const": true },
+        "execution_receipt_match": { "const": true },
+        "verification_result_match": { "const": true },
+        "subject_ref_match": { "const": true },
+        "recognition_index_binding_ok": { "const": true },
+        "recourse_index_binding_ok": { "const": true },
+        "recognition_precedes_recourse": { "const": true }
+      }
+    },
+    "limits": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "notes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    }
+  }
+}

--- a/tests/test_cross_stack_chain_bundle.py
+++ b/tests/test_cross_stack_chain_bundle.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+def load(rel):
+    return json.loads((ROOT / rel).read_text())
+
+def test_chain_bundle_core():
+    obj = load("evidence/chain/current/cross-stack-chain-bundle-0001.json")
+    idx = load("evidence/chain/current/index.json")
+    vr = load("verification/results/current/verification-result-0001.json")
+
+    assert obj["object_type"] == "CrossStackChainBundle"
+    assert obj["status"] == "ACTIVE_TRUTH"
+    assert obj["subject_artifact_id"] == "artifact-0005"
+    assert obj["subject_ref"] == "evidence/artifact-0005/artifact-0005.json"
+    assert obj["governing_refs"]["verification_result"] == "verification/results/current/verification-result-0001.json"
+    assert obj["binding_summary"]["verification_result_id"] == vr["verification_result_id"]
+    assert idx["current_chain_bundle_ref"] == "evidence/chain/current/cross-stack-chain-bundle-0001.json"
+    assert idx["entries"][0]["chain_bundle_id"] == obj["chain_bundle_id"]

--- a/tests/verify_cross_stack_chain_bundle_minimum.py
+++ b/tests/verify_cross_stack_chain_bundle_minimum.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ORG = ROOT.parent
+
+def load_json(path: Path):
+    if not path.exists():
+        raise SystemExit(f"FAIL missing-file {path}")
+    try:
+        return json.loads(path.read_text())
+    except Exception as e:
+        raise SystemExit(f"FAIL invalid-json {path}: {e}")
+
+def need(cond, msg):
+    if not cond:
+        raise SystemExit(f"FAIL {msg}")
+
+def gh_to_local(url: str):
+    m = re.match(r"^https://github\.com/Verifrax/([^/]+)/blob/main/(.+)$", url)
+    if not m:
+        return None
+    repo, rel = m.group(1), m.group(2)
+    return ORG / repo / rel
+
+chain = load_json(ROOT / "evidence/chain/current/cross-stack-chain-bundle-0001.json")
+index_obj = load_json(ROOT / "evidence/chain/current/index.json")
+schema = load_json(ROOT / "schemas/cross-stack-chain-bundle.schema.json")
+verification = load_json(ROOT / "verification/results/current/verification-result-0001.json")
+artifact = load_json(ROOT / "evidence/artifact-0005/artifact-0005.json")
+
+recognition = load_json(ORG / "ANAGNORIUM/recognitions/current/recognition-object-0001.json")
+recognition_index = load_json(ORG / "ANAGNORIUM/recognitions/current/index.json")
+recourse = load_json(ORG / "REGRESSORIUM/claims/current/recourse-object-0001.json")
+recourse_index = load_json(ORG / "REGRESSORIUM/claims/current/index.json")
+
+print("[VERIFY] files-present")
+
+need(chain["object_type"] == "CrossStackChainBundle", "chain bundle type")
+need(chain["status"] == "ACTIVE_TRUTH", "chain bundle status")
+need(chain["subject_artifact_id"] == "artifact-0005", "subject artifact id")
+need(chain["subject_ref"] == "evidence/artifact-0005/artifact-0005.json", "subject ref")
+need(chain["governing_refs"]["verification_result"] == "verification/results/current/verification-result-0001.json", "verification result ref")
+need(chain["index_refs"]["chain_index"] == "evidence/chain/current/index.json", "chain index ref")
+need(chain["index_refs"]["historical_archive"] == "evidence/chain/history/", "historical archive ref")
+
+print("[VERIFY] chain-bundle-core")
+
+need(index_obj["object_type"] == "CrossStackChainIndex", "chain index type")
+need(index_obj["status"] == "ACTIVE_TRUTH", "chain index status")
+need(index_obj["historical"] is False, "chain index historical false")
+need(index_obj["current_chain_bundle_ref"] == "evidence/chain/current/cross-stack-chain-bundle-0001.json", "current chain bundle ref")
+need(index_obj["entries"][0]["chain_bundle_id"] == chain["chain_bundle_id"], "index id matches")
+
+print("[VERIFY] chain-index-core")
+
+need(chain["binding_summary"]["verification_result_id"] == verification["verification_result_id"], "verification result id matches")
+need(chain["binding_summary"]["authority_id"] == verification["authority_id"], "authority id matches")
+need(chain["binding_summary"]["authority_seal_id"] == verification["authority_seal_id"], "authority seal id matches")
+need(chain["binding_summary"]["receipt_id"] == verification["receipt_id"], "receipt id matches")
+need(chain["binding_summary"]["canonical_semantic_sha256"] == verification["canonical_semantic_sha256"], "semantic sha matches")
+need(chain["subject_artifact_id"] == artifact["artifact_id"], "artifact id matches")
+
+print("[VERIFY] verification-binding-core")
+
+need(chain["governing_refs"]["recognition_object"] == "https://github.com/Verifrax/ANAGNORIUM/blob/main/recognitions/current/recognition-object-0001.json", "recognition object ref exact")
+need(chain["governing_refs"]["recourse_object"] == "https://github.com/Verifrax/REGRESSORIUM/blob/main/claims/current/recourse-object-0001.json", "recourse object ref exact")
+need(chain["binding_summary"]["recognition_object_id"] == recognition["recognition_object_id"], "recognition object id matches")
+need(chain["binding_summary"]["recourse_object_id"] == recourse["recourse_object_id"], "recourse object id matches")
+need(recognition_index["current_recognition_object_ref"] == "recognitions/current/recognition-object-0001.json", "recognition index bound")
+need(recourse_index["current_recourse_object_ref"] == "claims/current/recourse-object-0001.json", "recourse index bound")
+
+need(recognition["verification_result_ref"] == recourse["verification_result_ref"], "recognition/recourse verification ref match")
+need(recognition["accepted_epoch_ref"] == recourse["accepted_epoch_ref"], "recognition/recourse epoch ref match")
+need(recognition["authority_object_ref"] == recourse["authority_object_ref"], "recognition/recourse authority ref match")
+need(recognition["execution_receipt_ref"] == recourse["execution_receipt_ref"], "recognition/recourse receipt ref match")
+need(recognition["subject_ref"] == recourse["subject_ref"], "recognition/recourse subject ref match")
+
+print("[VERIFY] recognition-recourse-binding-core")
+
+for key, expected in [
+    ("law_version_match", True),
+    ("accepted_epoch_match", True),
+    ("authority_object_match", True),
+    ("execution_receipt_match", True),
+    ("verification_result_match", True),
+    ("subject_ref_match", True),
+    ("recognition_index_binding_ok", True),
+    ("recourse_index_binding_ok", True),
+    ("recognition_precedes_recourse", True),
+]:
+    need(chain["consistency"][key] is expected, f"consistency {key}")
+
+print("[VERIFY] consistency-core")
+
+try:
+    import jsonschema  # type: ignore
+except Exception:
+    print("[VERIFY] jsonschema-module absent -> structural verification only")
+else:
+    from jsonschema import Draft202012Validator
+    Draft202012Validator(schema).validate(chain)
+    print("[VERIFY] full-jsonschema-validation")
+
+print("[PASS] PHASE 3 / STEP 21 public chain bundle minimum verified")


### PR DESCRIPTION
## Summary

This change publishes the current machine-readable cross-stack chain bundle for the active artifact-0005 truth spine.

## Added

- current cross-stack chain bundle object
- current cross-stack chain index
- historical chain archive surface
- machine-readable chain-bundle schema
- chain-bundle validation and binding tests

## Updated

- active-truth evidence navigation pointers
- evidence README chain publication note

## Boundary effect

This change improves replayability and public binding legibility.

It does not replace chamber law objects.
It does not replace accepted epoch objects.
It does not replace authority issuance objects.
It does not replace execution receipt objects.
It does not replace verification result objects.
It does not replace recognition objects.
It does not replace recourse objects.

## Verification

- `python3 tests/verify_cross_stack_chain_bundle_minimum.py`
