### PR TITLE
Add VERIFRAX continuity and transfer objects for active chain survivability

### DIFF
--- a/evidence/CURRENT_STATE_INDEX.txt
+++ b/evidence/CURRENT_STATE_INDEX.txt
@@ -46,6 +46,10 @@ CURRENT_ARTIFACT_0005_BINDING:
 - VERIFICATION_RESULT_OBJECT: verification/results/current/verification-result-0001.json
 - CROSS_STACK_CHAIN_BUNDLE: evidence/chain/current/cross-stack-chain-bundle-0001.json
 - CROSS_STACK_CHAIN_INDEX: evidence/chain/current/index.json
+- CONTINUITY_OBJECT: evidence/continuity/current/continuity-object-0001.json
+- CONTINUITY_INDEX: evidence/continuity/current/index.json
+- TRANSFER_OBJECT: evidence/transfer/current/transfer-object-0001.json
+- TRANSFER_INDEX: evidence/transfer/current/index.json
 
 CURRENT_ROOT_SURFACES:
 - EVIDENCE_INDEX: evidence/README.md

--- a/evidence/README.md
+++ b/evidence/README.md
@@ -18,6 +18,9 @@ This index is not a substitute for the evidence objects themselves. It is the ca
 
 The current machine-readable cross-stack binding object is published at `chain/current/cross-stack-chain-bundle-0001.json` with index `chain/current/index.json`.
 
+The current machine-readable continuity object is published at `continuity/current/continuity-object-0001.json` with index `continuity/current/index.json`.
+The current machine-readable transfer object is published at `transfer/current/transfer-object-0001.json` with index `transfer/current/index.json`.
+
 ---
 
 ## Current boundary

--- a/evidence/STATUS_AUTHORITY_MAP.txt
+++ b/evidence/STATUS_AUTHORITY_MAP.txt
@@ -14,6 +14,10 @@ ROOT_STATUS_SURFACES:
 - CONSISTENCY_AUDIT = evidence/CONSISTENCY_AUDIT.txt
 - CROSS_STACK_CHAIN_BUNDLE = evidence/chain/current/cross-stack-chain-bundle-0001.json
 - CROSS_STACK_CHAIN_INDEX = evidence/chain/current/index.json
+- CONTINUITY_OBJECT: evidence/continuity/current/continuity-object-0001.json
+- CONTINUITY_INDEX: evidence/continuity/current/index.json
+- TRANSFER_OBJECT: evidence/transfer/current/transfer-object-0001.json
+- TRANSFER_INDEX: evidence/transfer/current/index.json
 
 CURRENT_AUTHORITY_ROOT:
 - GOVERNANCE_ROOT = github.com/Verifrax/.github

--- a/evidence/chain/current/cross-stack-chain-bundle-0001.json
+++ b/evidence/chain/current/cross-stack-chain-bundle-0001.json
@@ -18,13 +18,17 @@
     "execution_receipt": "https://github.com/Verifrax/CORPIFORM/blob/main/receipts/current/execution-receipt-0001.json",
     "verification_result": "verification/results/current/verification-result-0001.json",
     "recognition_object": "https://github.com/Verifrax/ANAGNORIUM/blob/main/recognitions/current/recognition-object-0001.json",
-    "recourse_object": "https://github.com/Verifrax/REGRESSORIUM/blob/main/claims/current/recourse-object-0001.json"
+    "recourse_object": "https://github.com/Verifrax/REGRESSORIUM/blob/main/claims/current/recourse-object-0001.json",
+    "continuity_object": "evidence/continuity/current/continuity-object-0001.json",
+    "transfer_object": "evidence/transfer/current/transfer-object-0001.json"
   },
   "index_refs": {
     "chain_index": "evidence/chain/current/index.json",
     "recognition_index": "https://github.com/Verifrax/ANAGNORIUM/blob/main/recognitions/current/index.json",
     "recourse_index": "https://github.com/Verifrax/REGRESSORIUM/blob/main/claims/current/index.json",
-    "historical_archive": "evidence/chain/history/"
+    "historical_archive": "evidence/chain/history/",
+    "continuity_index": "evidence/continuity/current/index.json",
+    "transfer_index": "evidence/transfer/current/index.json"
   },
   "binding_summary": {
     "authority_id": "AUTHORITY-0001-VERIFRAX",
@@ -47,16 +51,23 @@
     "subject_ref_match": true,
     "recognition_index_binding_ok": true,
     "recourse_index_binding_ok": true,
-    "recognition_precedes_recourse": true
+    "recognition_precedes_recourse": true,
+    "continuity_index_binding_ok": true,
+    "transfer_index_binding_ok": true,
+    "continuity_transfer_link_ok": true
   },
   "limits": [
     "this bundle records current cross-stack binding for artifact-0005 only",
     "this bundle does not replace law objects, accepted epoch objects, authority issuance objects, execution receipts, verification results, recognition objects, or recourse objects",
     "historical chain bundles must remain under evidence/chain/history/ and may not outrank this active bundle",
-    "this bundle is a machine-readable replay pointer surface, not a substitute for the underlying chamber objects"
+    "this bundle is a machine-readable replay pointer surface, not a substitute for the underlying chamber objects",
+    "continuity and transfer objects remain bounded replay-survival surfaces only",
+    "continuity and transfer do not replace chamber objects or governance authority"
   ],
   "notes": [
     "This object publishes the active cross-stack object chain for the current verified artifact-0005 boundary.",
-    "Its role is to let an outsider trace claim class, governing law, freeze, epoch, authority, receipt, verification, recognition, and recourse without founder narration."
+    "Its role is to let an outsider trace claim class, governing law, freeze, epoch, authority, receipt, verification, recognition, and recourse without founder narration.",
+    "The active chain now points to bounded continuity and transfer objects for survivability interpretation.",
+    "Those objects exist to preserve replay legibility under founder loss or platform relocation without redefining chamber authority."
   ]
 }

--- a/evidence/continuity/current/continuity-object-0001.json
+++ b/evidence/continuity/current/continuity-object-0001.json
@@ -1,0 +1,34 @@
+{
+  "object_type": "ContinuityObject",
+  "continuity_object_id": "continuity-object-0001",
+  "status": "ACTIVE_TRUTH",
+  "scope": "current bounded replay continuity for the active artifact-0005 chain",
+  "subject_artifact_id": "artifact-0005",
+  "subject_ref": "evidence/artifact-0005/artifact-0005.json",
+  "governing_law_version_ref": "https://github.com/Verifrax/SYNTAGMARIUM/blob/main/law/versions/current/law-version-0001.json",
+  "governing_freeze_object_ref": "https://github.com/Verifrax/SYNTAGMARIUM/blob/main/freeze/objects/current/freeze-object-0001.json",
+  "accepted_epoch_ref": "https://github.com/Verifrax/ORBISTIUM/blob/main/epochs/current/accepted-epoch-0001.json",
+  "authority_object_ref": "https://github.com/Verifrax/AUCTORISEAL/blob/main/authorities/current/authority-object-0001.json",
+  "verification_result_ref": "verification/results/current/verification-result-0001.json",
+  "chain_bundle_ref": "evidence/chain/current/cross-stack-chain-bundle-0001.json",
+  "release_integrity_ref": "release-integrity/README.md",
+  "archive_policy_ref": "docs/operations/ARCHIVE_POLICY.md",
+  "genesis_lineage_policy_ref": "docs/governance/GENESIS_LINEAGE_POLICY.md",
+  "freeze_manifest_ref": "freeze/FREEZE_SURFACE_MANIFEST.json",
+  "historical_archive_ref": "evidence/continuity/history/",
+  "continuity_guarantees": [
+    "active cross-stack chain binding is published as a machine-readable replay surface",
+    "historical materials remain subordinate and may not outrank active current truth",
+    "release-integrity and archive-policy surfaces preserve replay interpretation beyond a single release moment",
+    "freeze and lineage surfaces preserve reconstruction context across repository history"
+  ],
+  "failure_model": [
+    "founder absence does not by itself invalidate published active objects",
+    "platform relocation does not by itself redefine governing law, epoch, authority, verification, recognition, or recourse objects",
+    "historical mirrors remain non-active unless current truth explicitly points to them"
+  ],
+  "notes": [
+    "This object states how bounded replay continuity is preserved for the current active chain.",
+    "It does not replace law, authority, verification, recognition, recourse, or freeze objects."
+  ]
+}

--- a/evidence/continuity/current/index.json
+++ b/evidence/continuity/current/index.json
@@ -1,0 +1,13 @@
+{
+  "object_type": "ContinuityIndex",
+  "status": "ACTIVE_TRUTH",
+  "historical": false,
+  "current_continuity_object_ref": "evidence/continuity/current/continuity-object-0001.json",
+  "entries": [
+    {
+      "continuity_object_id": "continuity-object-0001",
+      "path": "evidence/continuity/current/continuity-object-0001.json",
+      "subject_artifact_id": "artifact-0005"
+    }
+  ]
+}

--- a/evidence/continuity/history/README.md
+++ b/evidence/continuity/history/README.md
@@ -1,0 +1,7 @@
+# Historical continuity objects
+
+This directory stores superseded or historical continuity objects only.
+
+Historical continuity material remains auditable and reconstructable.
+
+Nothing here may outrank the active continuity object published under `evidence/continuity/current/`.

--- a/evidence/transfer/current/index.json
+++ b/evidence/transfer/current/index.json
@@ -1,0 +1,13 @@
+{
+  "object_type": "TransferIndex",
+  "status": "ACTIVE_TRUTH",
+  "historical": false,
+  "current_transfer_object_ref": "evidence/transfer/current/transfer-object-0001.json",
+  "entries": [
+    {
+      "transfer_object_id": "transfer-object-0001",
+      "path": "evidence/transfer/current/transfer-object-0001.json",
+      "subject_artifact_id": "artifact-0005"
+    }
+  ]
+}

--- a/evidence/transfer/current/transfer-object-0001.json
+++ b/evidence/transfer/current/transfer-object-0001.json
@@ -1,0 +1,31 @@
+{
+  "object_type": "TransferObject",
+  "transfer_object_id": "transfer-object-0001",
+  "status": "ACTIVE_TRUTH",
+  "scope": "current bounded continuity transfer interpretation for the active artifact-0005 chain",
+  "subject_artifact_id": "artifact-0005",
+  "subject_ref": "evidence/artifact-0005/artifact-0005.json",
+  "continuity_object_ref": "evidence/continuity/current/continuity-object-0001.json",
+  "governing_law_version_ref": "https://github.com/Verifrax/SYNTAGMARIUM/blob/main/law/versions/current/law-version-0001.json",
+  "authority_object_ref": "https://github.com/Verifrax/AUCTORISEAL/blob/main/authorities/current/authority-object-0001.json",
+  "chain_bundle_ref": "evidence/chain/current/cross-stack-chain-bundle-0001.json",
+  "archive_policy_ref": "docs/operations/ARCHIVE_POLICY.md",
+  "release_integrity_ref": "release-integrity/README.md",
+  "genesis_lineage_policy_ref": "docs/governance/GENESIS_LINEAGE_POLICY.md",
+  "historical_archive_ref": "evidence/transfer/history/",
+  "transfer_conditions": [
+    "active object paths must remain explicit and machine-readable",
+    "historical mirrors must remain subordinate to active current truth",
+    "repository lineage and archive surfaces must remain sufficient for bounded replay interpretation",
+    "transfer does not authorize mutation of law, epoch, authority, verification, recognition, or recourse objects"
+  ],
+  "bounded_survival_reading": [
+    "continuity survives founder loss by published object linkage and replay surfaces",
+    "continuity survives platform loss only through reconstructable published objects, archives, and lineage policy",
+    "transfer interpretation remains bounded to published active-truth surfaces"
+  ],
+  "notes": [
+    "This object defines the bounded transfer reading for continuity of the active chain.",
+    "It is not a substitute for chamber objects or governance authority."
+  ]
+}

--- a/evidence/transfer/history/README.md
+++ b/evidence/transfer/history/README.md
@@ -1,0 +1,7 @@
+# Historical transfer objects
+
+This directory stores superseded or historical transfer objects only.
+
+Historical transfer material remains auditable and reconstructable.
+
+Nothing here may outrank the active transfer object published under `evidence/transfer/current/`.

--- a/schemas/continuity-object.schema.json
+++ b/schemas/continuity-object.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://verifrax.net/schemas/continuity-object.schema.json",
+  "title": "VERIFRAX Continuity Object",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "object_type",
+    "continuity_object_id",
+    "status",
+    "scope",
+    "subject_artifact_id",
+    "subject_ref",
+    "governing_law_version_ref",
+    "authority_object_ref",
+    "chain_bundle_ref",
+    "historical_archive_ref",
+    "continuity_guarantees",
+    "failure_model",
+    "notes"
+  ],
+  "properties": {
+    "object_type": { "type": "string", "const": "ContinuityObject" },
+    "continuity_object_id": { "type": "string", "minLength": 1 },
+    "status": { "type": "string", "const": "ACTIVE_TRUTH" },
+    "scope": { "type": "string", "minLength": 1 },
+    "subject_artifact_id": { "type": "string", "minLength": 1 },
+    "subject_ref": { "type": "string", "minLength": 1 },
+    "governing_law_version_ref": { "type": "string", "minLength": 1 },
+    "governing_freeze_object_ref": { "type": "string", "minLength": 1 },
+    "accepted_epoch_ref": { "type": "string", "minLength": 1 },
+    "authority_object_ref": { "type": "string", "minLength": 1 },
+    "verification_result_ref": { "type": "string", "minLength": 1 },
+    "chain_bundle_ref": { "type": "string", "minLength": 1 },
+    "release_integrity_ref": { "type": "string", "minLength": 1 },
+    "archive_policy_ref": { "type": "string", "minLength": 1 },
+    "genesis_lineage_policy_ref": { "type": "string", "minLength": 1 },
+    "freeze_manifest_ref": { "type": "string", "minLength": 1 },
+    "historical_archive_ref": { "type": "string", "minLength": 1 },
+    "continuity_guarantees": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "failure_model": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "notes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    }
+  }
+}

--- a/schemas/transfer-object.schema.json
+++ b/schemas/transfer-object.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://verifrax.net/schemas/transfer-object.schema.json",
+  "title": "VERIFRAX Transfer Object",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "object_type",
+    "transfer_object_id",
+    "status",
+    "scope",
+    "subject_artifact_id",
+    "subject_ref",
+    "continuity_object_ref",
+    "governing_law_version_ref",
+    "authority_object_ref",
+    "chain_bundle_ref",
+    "historical_archive_ref",
+    "transfer_conditions",
+    "bounded_survival_reading",
+    "notes"
+  ],
+  "properties": {
+    "object_type": { "type": "string", "const": "TransferObject" },
+    "transfer_object_id": { "type": "string", "minLength": 1 },
+    "status": { "type": "string", "const": "ACTIVE_TRUTH" },
+    "scope": { "type": "string", "minLength": 1 },
+    "subject_artifact_id": { "type": "string", "minLength": 1 },
+    "subject_ref": { "type": "string", "minLength": 1 },
+    "continuity_object_ref": { "type": "string", "minLength": 1 },
+    "governing_law_version_ref": { "type": "string", "minLength": 1 },
+    "authority_object_ref": { "type": "string", "minLength": 1 },
+    "chain_bundle_ref": { "type": "string", "minLength": 1 },
+    "archive_policy_ref": { "type": "string", "minLength": 1 },
+    "release_integrity_ref": { "type": "string", "minLength": 1 },
+    "genesis_lineage_policy_ref": { "type": "string", "minLength": 1 },
+    "historical_archive_ref": { "type": "string", "minLength": 1 },
+    "transfer_conditions": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "bounded_survival_reading": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "notes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    }
+  }
+}

--- a/tests/test_continuity_transfer_objects.py
+++ b/tests/test_continuity_transfer_objects.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+def load(rel: str):
+    return json.loads((ROOT / rel).read_text())
+
+def test_continuity_transfer_minimum():
+    continuity = load("evidence/continuity/current/continuity-object-0001.json")
+    continuity_index = load("evidence/continuity/current/index.json")
+    transfer = load("evidence/transfer/current/transfer-object-0001.json")
+    transfer_index = load("evidence/transfer/current/index.json")
+    bundle = load("evidence/chain/current/cross-stack-chain-bundle-0001.json")
+
+    assert continuity["object_type"] == "ContinuityObject"
+    assert continuity["status"] == "ACTIVE_TRUTH"
+    assert continuity_index["current_continuity_object_ref"] == "evidence/continuity/current/continuity-object-0001.json"
+
+    assert transfer["object_type"] == "TransferObject"
+    assert transfer["status"] == "ACTIVE_TRUTH"
+    assert transfer["continuity_object_ref"] == "evidence/continuity/current/continuity-object-0001.json"
+    assert transfer_index["current_transfer_object_ref"] == "evidence/transfer/current/transfer-object-0001.json"
+
+    assert bundle["governing_refs"]["continuity_object"] == "evidence/continuity/current/continuity-object-0001.json"
+    assert bundle["governing_refs"]["transfer_object"] == "evidence/transfer/current/transfer-object-0001.json"
+    assert bundle["index_refs"]["continuity_index"] == "evidence/continuity/current/index.json"
+    assert bundle["index_refs"]["transfer_index"] == "evidence/transfer/current/index.json"

--- a/tests/verify_continuity_transfer_minimum.py
+++ b/tests/verify_continuity_transfer_minimum.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+def need(ok, label):
+    if not ok:
+        raise SystemExit(f"FAIL {label}")
+    print(f"[VERIFY] {label}")
+
+def load(rel):
+    return json.loads((ROOT / rel).read_text())
+
+required_files = [
+    "evidence/continuity/current/continuity-object-0001.json",
+    "evidence/continuity/current/index.json",
+    "evidence/continuity/history/README.md",
+    "evidence/transfer/current/transfer-object-0001.json",
+    "evidence/transfer/current/index.json",
+    "evidence/transfer/history/README.md",
+    "schemas/continuity-object.schema.json",
+    "schemas/transfer-object.schema.json",
+    "evidence/chain/current/cross-stack-chain-bundle-0001.json",
+    "tests/test_continuity_transfer_objects.py"
+]
+for rel in required_files:
+    need((ROOT / rel).exists(), f"file-present {rel}")
+
+continuity = load("evidence/continuity/current/continuity-object-0001.json")
+continuity_index = load("evidence/continuity/current/index.json")
+transfer = load("evidence/transfer/current/transfer-object-0001.json")
+transfer_index = load("evidence/transfer/current/index.json")
+bundle = load("evidence/chain/current/cross-stack-chain-bundle-0001.json")
+
+need(continuity["object_type"] == "ContinuityObject", "continuity-object-type")
+need(continuity["status"] == "ACTIVE_TRUTH", "continuity-status")
+need(continuity["historical_archive_ref"] == "evidence/continuity/history/", "continuity-history-ref")
+need(continuity_index["current_continuity_object_ref"] == "evidence/continuity/current/continuity-object-0001.json", "continuity-index-binding")
+need(continuity_index["historical"] is False, "continuity-index-historical-false")
+
+need(transfer["object_type"] == "TransferObject", "transfer-object-type")
+need(transfer["status"] == "ACTIVE_TRUTH", "transfer-status")
+need(transfer["continuity_object_ref"] == "evidence/continuity/current/continuity-object-0001.json", "transfer-links-continuity")
+need(transfer["historical_archive_ref"] == "evidence/transfer/history/", "transfer-history-ref")
+need(transfer_index["current_transfer_object_ref"] == "evidence/transfer/current/transfer-object-0001.json", "transfer-index-binding")
+need(transfer_index["historical"] is False, "transfer-index-historical-false")
+
+need(bundle["governing_refs"]["continuity_object"] == "evidence/continuity/current/continuity-object-0001.json", "bundle-continuity-ref")
+need(bundle["governing_refs"]["transfer_object"] == "evidence/transfer/current/transfer-object-0001.json", "bundle-transfer-ref")
+need(bundle["index_refs"]["continuity_index"] == "evidence/continuity/current/index.json", "bundle-continuity-index")
+need(bundle["index_refs"]["transfer_index"] == "evidence/transfer/current/index.json", "bundle-transfer-index")
+need(bundle["consistency"]["continuity_index_binding_ok"] is True, "bundle-continuity-consistency")
+need(bundle["consistency"]["transfer_index_binding_ok"] is True, "bundle-transfer-consistency")
+need(bundle["consistency"]["continuity_transfer_link_ok"] is True, "bundle-continuity-transfer-link")
+
+print("[PASS] PHASE 3 / STEP 29 continuity-transfer minimum verified")


### PR DESCRIPTION
## Summary

Publish bounded machine-readable continuity and transfer objects for the active artifact-0005 cross-stack chain.

## What changed

- adds `evidence/continuity/current/continuity-object-0001.json`
- adds `evidence/continuity/current/index.json`
- adds `evidence/continuity/history/README.md`
- adds `evidence/transfer/current/transfer-object-0001.json`
- adds `evidence/transfer/current/index.json`
- adds `evidence/transfer/history/README.md`
- adds `schemas/continuity-object.schema.json`
- adds `schemas/transfer-object.schema.json`
- wires continuity and transfer refs into `evidence/chain/current/cross-stack-chain-bundle-0001.json`
- updates current root evidence pointers in `evidence/CURRENT_STATE_INDEX.txt`, `evidence/STATUS_AUTHORITY_MAP.txt`, and `evidence/README.md`
- adds continuity / transfer minimum verification tests

## Boundary

These objects define bounded replay survivability only.

They do not replace chamber law objects.
They do not replace accepted epoch objects.
They do not replace authority issuance objects.
They do not replace execution receipt objects.
They do not replace verification result objects.
They do not replace recognition objects.
They do not replace recourse objects.
They do not create a second authority line.

## Verification

- `python3 tests/verify_continuity_transfer_minimum.py`
