### PR TITLE
Add VERIFRAX current verification index and end-to-end chain bindings

### DIFF
--- a/evidence/chain/current/cross-stack-chain-bundle-0001.json
+++ b/evidence/chain/current/cross-stack-chain-bundle-0001.json
@@ -20,7 +20,9 @@
     "recognition_object": "https://github.com/Verifrax/ANAGNORIUM/blob/main/recognitions/current/recognition-object-0001.json",
     "recourse_object": "https://github.com/Verifrax/REGRESSORIUM/blob/main/claims/current/recourse-object-0001.json",
     "continuity_object": "evidence/continuity/current/continuity-object-0001.json",
-    "transfer_object": "evidence/transfer/current/transfer-object-0001.json"
+    "transfer_object": "evidence/transfer/current/transfer-object-0001.json",
+    "continuity": "evidence/continuity/current/continuity-object-0001.json",
+    "transfer": "evidence/transfer/current/transfer-object-0001.json"
   },
   "index_refs": {
     "chain_index": "evidence/chain/current/index.json",
@@ -40,7 +42,9 @@
     "node_verdict": "VERIFIED",
     "rust_verdict": "VERIFIED",
     "cross_implementation_match": "MATCH",
-    "canonical_semantic_sha256": "801c87f08221ac194282b1a2e7f58cac2dcc143f6944c98a888edc086a72fc6b"
+    "canonical_semantic_sha256": "801c87f08221ac194282b1a2e7f58cac2dcc143f6944c98a888edc086a72fc6b",
+    "continuity_object_id": "continuity-object-0001",
+    "transfer_object_id": "transfer-object-0001"
   },
   "consistency": {
     "law_version_match": true,
@@ -69,5 +73,10 @@
     "Its role is to let an outsider trace claim class, governing law, freeze, epoch, authority, receipt, verification, recognition, and recourse without founder narration.",
     "The active chain now points to bounded continuity and transfer objects for survivability interpretation.",
     "Those objects exist to preserve replay legibility under founder loss or platform relocation without redefining chamber authority."
-  ]
+  ],
+  "integrity_checks": {
+    "verification_result_match": true,
+    "continuity_match": true,
+    "transfer_match": true
+  }
 }

--- a/schemas/cross-stack-chain-bundle.schema.json
+++ b/schemas/cross-stack-chain-bundle.schema.json
@@ -20,12 +20,27 @@
     "notes"
   ],
   "properties": {
-    "object_type": { "const": "CrossStackChainBundle" },
-    "chain_bundle_id": { "type": "string", "minLength": 1 },
-    "status": { "const": "ACTIVE_TRUTH" },
-    "subject_artifact_id": { "const": "artifact-0005" },
-    "subject_ref": { "type": "string", "minLength": 1 },
-    "execution_subject_ref": { "type": "string", "minLength": 1 },
+    "object_type": {
+      "const": "CrossStackChainBundle"
+    },
+    "chain_bundle_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "const": "ACTIVE_TRUTH"
+    },
+    "subject_artifact_id": {
+      "const": "artifact-0005"
+    },
+    "subject_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "execution_subject_ref": {
+      "type": "string",
+      "minLength": 1
+    },
     "claim_class_refs": {
       "type": "object",
       "additionalProperties": false,
@@ -35,9 +50,18 @@
         "recourse_object"
       ],
       "properties": {
-        "verification_result": { "type": "string", "minLength": 1 },
-        "recognition_object": { "type": "string", "minLength": 1 },
-        "recourse_object": { "type": "string", "minLength": 1 }
+        "verification_result": {
+          "type": "string",
+          "minLength": 1
+        },
+        "recognition_object": {
+          "type": "string",
+          "minLength": 1
+        },
+        "recourse_object": {
+          "type": "string",
+          "minLength": 1
+        }
       }
     },
     "governing_refs": {
@@ -51,17 +75,51 @@
         "execution_receipt",
         "verification_result",
         "recognition_object",
-        "recourse_object"
+        "recourse_object",
+        "continuity",
+        "transfer"
       ],
       "properties": {
-        "law_version": { "type": "string", "minLength": 1 },
-        "freeze_object": { "type": "string", "minLength": 1 },
-        "accepted_epoch": { "type": "string", "minLength": 1 },
-        "authority_object": { "type": "string", "minLength": 1 },
-        "execution_receipt": { "type": "string", "minLength": 1 },
-        "verification_result": { "type": "string", "minLength": 1 },
-        "recognition_object": { "type": "string", "minLength": 1 },
-        "recourse_object": { "type": "string", "minLength": 1 }
+        "law_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "freeze_object": {
+          "type": "string",
+          "minLength": 1
+        },
+        "accepted_epoch": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_object": {
+          "type": "string",
+          "minLength": 1
+        },
+        "execution_receipt": {
+          "type": "string",
+          "minLength": 1
+        },
+        "verification_result": {
+          "type": "string",
+          "minLength": 1
+        },
+        "recognition_object": {
+          "type": "string",
+          "minLength": 1
+        },
+        "recourse_object": {
+          "type": "string",
+          "minLength": 1
+        },
+        "continuity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "transfer": {
+          "type": "string",
+          "minLength": 1
+        }
       }
     },
     "index_refs": {
@@ -74,10 +132,22 @@
         "historical_archive"
       ],
       "properties": {
-        "chain_index": { "type": "string", "minLength": 1 },
-        "recognition_index": { "type": "string", "minLength": 1 },
-        "recourse_index": { "type": "string", "minLength": 1 },
-        "historical_archive": { "type": "string", "minLength": 1 }
+        "chain_index": {
+          "type": "string",
+          "minLength": 1
+        },
+        "recognition_index": {
+          "type": "string",
+          "minLength": 1
+        },
+        "recourse_index": {
+          "type": "string",
+          "minLength": 1
+        },
+        "historical_archive": {
+          "type": "string",
+          "minLength": 1
+        }
       }
     },
     "binding_summary": {
@@ -93,21 +163,58 @@
         "node_verdict",
         "rust_verdict",
         "cross_implementation_match",
-        "canonical_semantic_sha256"
+        "canonical_semantic_sha256",
+        "continuity_object_id",
+        "transfer_object_id"
       ],
       "properties": {
-        "authority_id": { "type": "string", "minLength": 1 },
-        "authority_seal_id": { "type": "string", "minLength": 1 },
-        "receipt_id": { "type": "string", "minLength": 1 },
-        "verification_result_id": { "type": "string", "minLength": 1 },
-        "recognition_object_id": { "type": "string", "minLength": 1 },
-        "recourse_object_id": { "type": "string", "minLength": 1 },
-        "node_verdict": { "type": "string", "minLength": 1 },
-        "rust_verdict": { "type": "string", "minLength": 1 },
-        "cross_implementation_match": { "type": "string", "minLength": 1 },
+        "authority_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authority_seal_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "receipt_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "verification_result_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "recognition_object_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "recourse_object_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "node_verdict": {
+          "type": "string",
+          "minLength": 1
+        },
+        "rust_verdict": {
+          "type": "string",
+          "minLength": 1
+        },
+        "cross_implementation_match": {
+          "type": "string",
+          "minLength": 1
+        },
         "canonical_semantic_sha256": {
           "type": "string",
           "pattern": "^[a-f0-9]{64}$"
+        },
+        "continuity_object_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "transfer_object_id": {
+          "type": "string",
+          "minLength": 1
         }
       }
     },
@@ -126,26 +233,68 @@
         "recognition_precedes_recourse"
       ],
       "properties": {
-        "law_version_match": { "const": true },
-        "accepted_epoch_match": { "const": true },
-        "authority_object_match": { "const": true },
-        "execution_receipt_match": { "const": true },
-        "verification_result_match": { "const": true },
-        "subject_ref_match": { "const": true },
-        "recognition_index_binding_ok": { "const": true },
-        "recourse_index_binding_ok": { "const": true },
-        "recognition_precedes_recourse": { "const": true }
+        "law_version_match": {
+          "const": true
+        },
+        "accepted_epoch_match": {
+          "const": true
+        },
+        "authority_object_match": {
+          "const": true
+        },
+        "execution_receipt_match": {
+          "const": true
+        },
+        "verification_result_match": {
+          "const": true
+        },
+        "subject_ref_match": {
+          "const": true
+        },
+        "recognition_index_binding_ok": {
+          "const": true
+        },
+        "recourse_index_binding_ok": {
+          "const": true
+        },
+        "recognition_precedes_recourse": {
+          "const": true
+        }
       }
     },
     "limits": {
       "type": "array",
       "minItems": 1,
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     },
     "notes": {
       "type": "array",
       "minItems": 1,
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "integrity_checks": {
+      "properties": {
+        "verification_result_match": {
+          "const": true
+        },
+        "continuity_match": {
+          "const": true
+        },
+        "transfer_match": {
+          "const": true
+        }
+      },
+      "required": [
+        "verification_result_match",
+        "continuity_match",
+        "transfer_match"
+      ]
     }
   }
 }

--- a/tests/test_end_to_end_chain_minimum.py
+++ b/tests/test_end_to_end_chain_minimum.py
@@ -1,0 +1,41 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+def load(rel: str):
+    return json.loads((ROOT / rel).read_text(encoding="utf-8"))
+
+def test_verification_result_index_and_chain_are_bound():
+    vr = load("verification/results/current/verification-result-0001.json")
+    index = load("verification/results/current/index.json")
+    chain = load("evidence/chain/current/cross-stack-chain-bundle-0001.json")
+
+    assert index["object_type"] == "VERIFICATION_RESULT_INDEX"
+    assert index["status"] == "ACTIVE_TRUTH"
+    assert index["historical"] is False
+    assert index["current_verification_result_ref"] == "verification/results/current/verification-result-0001.json"
+    assert index["historical_archive_ref"] == "verification/results/history/"
+
+    entry = index["entries"][0]
+    assert entry["verification_result_id"] == vr["verification_result_id"]
+    assert entry["path"] == "verification/results/current/verification-result-0001.json"
+    assert entry["receipt_id"] == vr["receipt_id"]
+    assert entry["authority_seal_id"] == vr["authority_seal_id"]
+
+    assert vr["current_index_ref"] == "verification/results/current/index.json"
+    assert vr["historical_archive_ref"] == "verification/results/history/"
+    assert vr["continuity_ref"] == "evidence/continuity/current/continuity-object-0001.json"
+    assert vr["transfer_ref"] == "evidence/transfer/current/transfer-object-0001.json"
+
+    assert chain["governing_refs"]["verification_result"] == "verification/results/current/verification-result-0001.json"
+    assert chain["governing_refs"]["continuity"] == "evidence/continuity/current/continuity-object-0001.json"
+    assert chain["governing_refs"]["transfer"] == "evidence/transfer/current/transfer-object-0001.json"
+
+    assert chain["binding_summary"]["verification_result_id"] == vr["verification_result_id"]
+    assert chain["binding_summary"]["continuity_object_id"] == "continuity-object-0001"
+    assert chain["binding_summary"]["transfer_object_id"] == "transfer-object-0001"
+
+    assert chain["integrity_checks"]["verification_result_match"] is True
+    assert chain["integrity_checks"]["continuity_match"] is True
+    assert chain["integrity_checks"]["transfer_match"] is True

--- a/tests/test_verification_result_object.py
+++ b/tests/test_verification_result_object.py
@@ -3,25 +3,25 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
+def load(rel: str):
+    return json.loads((ROOT / rel).read_text(encoding="utf-8"))
+
 def test_verification_result_object_minimum():
-    p = ROOT / verification/results/current/verification-result-0001.json
-    assert p.is_file()
-    data = json.loads(p.read_text())
-    assert data[object_type] == VerificationResult
-    assert data[verification_result_id] == verification-result-0001
-    assert data[status] == ACTIVE_TRUTH
-    assert data[artifact_id] == artifact-0005
-    assert data[verdict] == VERIFIED
-    assert data[claim_class_ref] == Verifrax/SYNTAGMARIUM/claim-classes/verification-result.json
-    assert data[governing_law_version_ref] == Verifrax/SYNTAGMARIUM/law/versions/current/law-version-0001.json
-    assert data[governing_freeze_object_ref] == Verifrax/SYNTAGMARIUM/freeze/objects/current/freeze-object-0001.json
-    assert data[canonical_semantic_sha256] == 801c87f08221ac194282b1a2e7f58cac2dcc143f6944c98a888edc086a72fc6b
-    for key in [
-        artifact_ref, node_verdict_ref, node_semantic_ref, rust_verdict_ref,
-        rust_semantic_ref, cross_implementation_ref
-    ]:
-        assert (ROOT / data[key]).is_file(), key
-    node = json.loads((ROOT / data[node_semantic_ref]).read_text())
-    rust = json.loads((ROOT / data[rust_semantic_ref]).read_text())
-    assert node == rust
-    assert node[verdict] == data[verdict]
+    data = load("verification/results/current/verification-result-0001.json")
+
+    assert data["verification_result_id"] == "verification-result-0001"
+    assert data["claim_class_ref"] == "Verifrax/SYNTAGMARIUM/claim-classes/verification-result.json"
+    assert data["governing_law_version_ref"] == "Verifrax/SYNTAGMARIUM/law/versions/current/law-version-0001.json"
+
+    assert "receipt_id" in data and isinstance(data["receipt_id"], str) and data["receipt_id"]
+    assert "authority_seal_id" in data and isinstance(data["authority_seal_id"], str) and data["authority_seal_id"]
+    assert "historical_archive_ref" in data and data["historical_archive_ref"] == "verification/results/history/"
+    assert "current_index_ref" in data and data["current_index_ref"] == "verification/results/current/index.json"
+
+    assert data["accepted_epoch_ref"] == "https://github.com/Verifrax/ORBISTIUM/blob/main/epochs/current/accepted-epoch-0001.json"
+    assert data["authority_object_ref"] == "https://github.com/Verifrax/AUCTORISEAL/blob/main/authorities/current/authority-object-0001.json"
+    assert data["execution_receipt_ref"] == "https://github.com/Verifrax/CORPIFORM/blob/main/receipts/current/execution-receipt-0001.json"
+    assert data["recognition_object_ref"] == "https://github.com/Verifrax/ANAGNORIUM/blob/main/recognitions/current/recognition-object-0001.json"
+    assert data["recourse_object_ref"] == "https://github.com/Verifrax/REGRESSORIUM/blob/main/claims/current/recourse-object-0001.json"
+    assert data["continuity_ref"] == "evidence/continuity/current/continuity-object-0001.json"
+    assert data["transfer_ref"] == "evidence/transfer/current/transfer-object-0001.json"

--- a/tests/verify_end_to_end_chain_minimum.py
+++ b/tests/verify_end_to_end_chain_minimum.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+errors = []
+
+def load(rel: str):
+    return json.loads((ROOT / rel).read_text(encoding="utf-8"))
+
+def need(condition, label):
+    if condition:
+        print(f"[VERIFY] {label}")
+    else:
+        errors.append(label)
+
+for rel in [
+    "verification/results/current/verification-result-0001.json",
+    "verification/results/current/index.json",
+    "verification/results/history/README.md",
+    "evidence/chain/current/cross-stack-chain-bundle-0001.json",
+    "schemas/cross-stack-chain-bundle.schema.json",
+    "tests/test_end_to_end_chain_minimum.py",
+]:
+    need((ROOT / rel).exists(), f"file-present {rel}")
+
+vr = load("verification/results/current/verification-result-0001.json")
+idx = load("verification/results/current/index.json")
+chain = load("evidence/chain/current/cross-stack-chain-bundle-0001.json")
+
+need(idx.get("object_type") == "VERIFICATION_RESULT_INDEX", "verification-index-type")
+need(idx.get("status") == "ACTIVE_TRUTH", "verification-index-status")
+need(idx.get("historical") is False, "verification-index-historical-false")
+need(idx.get("current_verification_result_ref") == "verification/results/current/verification-result-0001.json", "verification-index-binding")
+need(idx.get("historical_archive_ref") == "verification/results/history/", "verification-index-history-ref")
+
+entries = idx.get("entries", [])
+need(len(entries) >= 1, "verification-index-entry-present")
+first = entries[0] if entries else {}
+need(first.get("verification_result_id") == vr.get("verification_result_id"), "verification-index-entry-id")
+need(first.get("path") == "verification/results/current/verification-result-0001.json", "verification-index-entry-path")
+need(first.get("receipt_id") == vr.get("receipt_id"), "verification-index-entry-receipt-id")
+need(first.get("authority_seal_id") == vr.get("authority_seal_id"), "verification-index-entry-authority-seal-id")
+
+need(vr.get("current_index_ref") == "verification/results/current/index.json", "verification-result-index-ref")
+need(vr.get("historical_archive_ref") == "verification/results/history/", "verification-result-history-ref")
+need(vr.get("accepted_epoch_ref") == "https://github.com/Verifrax/ORBISTIUM/blob/main/epochs/current/accepted-epoch-0001.json", "verification-result-epoch-ref")
+need(vr.get("authority_object_ref") == "https://github.com/Verifrax/AUCTORISEAL/blob/main/authorities/current/authority-object-0001.json", "verification-result-authority-ref")
+need(vr.get("execution_receipt_ref") == "https://github.com/Verifrax/CORPIFORM/blob/main/receipts/current/execution-receipt-0001.json", "verification-result-receipt-ref")
+need(vr.get("recognition_object_ref") == "https://github.com/Verifrax/ANAGNORIUM/blob/main/recognitions/current/recognition-object-0001.json", "verification-result-recognition-ref")
+need(vr.get("recourse_object_ref") == "https://github.com/Verifrax/REGRESSORIUM/blob/main/claims/current/recourse-object-0001.json", "verification-result-recourse-ref")
+need(vr.get("continuity_ref") == "evidence/continuity/current/continuity-object-0001.json", "verification-result-continuity-ref")
+need(vr.get("transfer_ref") == "evidence/transfer/current/transfer-object-0001.json", "verification-result-transfer-ref")
+
+gov = chain.get("governing_refs", {})
+need(gov.get("verification_result") == "verification/results/current/verification-result-0001.json", "chain-verification-ref")
+need(gov.get("continuity") == "evidence/continuity/current/continuity-object-0001.json", "chain-continuity-ref")
+need(gov.get("transfer") == "evidence/transfer/current/transfer-object-0001.json", "chain-transfer-ref")
+
+summary = chain.get("binding_summary", {})
+need(summary.get("verification_result_id") == vr.get("verification_result_id"), "chain-verification-id-match")
+need(summary.get("continuity_object_id") == "continuity-object-0001", "chain-continuity-id")
+need(summary.get("transfer_object_id") == "transfer-object-0001", "chain-transfer-id")
+
+checks = chain.get("integrity_checks", {})
+need(checks.get("verification_result_match") is True, "chain-verification-match")
+need(checks.get("continuity_match") is True, "chain-continuity-match")
+need(checks.get("transfer_match") is True, "chain-transfer-match")
+
+if errors:
+    print("[FAIL] PHASE 5 / STEP 93 end-to-end chain minimum verification failed")
+    for e in errors:
+        print(f" - {e}")
+    sys.exit(1)
+
+print("[PASS] PHASE 5 / STEP 93 end-to-end chain minimum verified")

--- a/verification/results/current/index.json
+++ b/verification/results/current/index.json
@@ -1,0 +1,15 @@
+{
+  "object_type": "VERIFICATION_RESULT_INDEX",
+  "status": "ACTIVE_TRUTH",
+  "historical": false,
+  "current_verification_result_ref": "verification/results/current/verification-result-0001.json",
+  "historical_archive_ref": "verification/results/history/",
+  "entries": [
+    {
+      "verification_result_id": "verification-result-0001",
+      "path": "verification/results/current/verification-result-0001.json",
+      "receipt_id": "8F88E46F-625B-4682-BF9A-D68ADD241FFF",
+      "authority_seal_id": "seal_9c1568bb9ef7423283ca56ecdb7dc278"
+    }
+  ]
+}

--- a/verification/results/current/verification-result-0001.json
+++ b/verification/results/current/verification-result-0001.json
@@ -23,5 +23,14 @@
   "verdict": "VERIFIED",
   "derivation_rule": "This object is admitted as current verification truth only because the maintained Node and Rust semantic outputs for artifact-0005 matched byte-for-byte after canonicalization and the root evidence surfaces record artifact-0005 as VERIFIED in current truth.",
   "current_truth_scope": "artifact-0005 verified governed execution boundary only",
-  "historical_boundary": "Historical verification materials must remain under verification/results/history/ or explicitly historical evidence surfaces and must not outrank this active object."
+  "historical_boundary": "Historical verification materials must remain under verification/results/history/ or explicitly historical evidence surfaces and must not outrank this active object.",
+  "historical_archive_ref": "verification/results/history/",
+  "current_index_ref": "verification/results/current/index.json",
+  "accepted_epoch_ref": "https://github.com/Verifrax/ORBISTIUM/blob/main/epochs/current/accepted-epoch-0001.json",
+  "authority_object_ref": "https://github.com/Verifrax/AUCTORISEAL/blob/main/authorities/current/authority-object-0001.json",
+  "execution_receipt_ref": "https://github.com/Verifrax/CORPIFORM/blob/main/receipts/current/execution-receipt-0001.json",
+  "recognition_object_ref": "https://github.com/Verifrax/ANAGNORIUM/blob/main/recognitions/current/recognition-object-0001.json",
+  "recourse_object_ref": "https://github.com/Verifrax/REGRESSORIUM/blob/main/claims/current/recourse-object-0001.json",
+  "continuity_ref": "evidence/continuity/current/continuity-object-0001.json",
+  "transfer_ref": "evidence/transfer/current/transfer-object-0001.json"
 }

--- a/verification/results/history/README.md
+++ b/verification/results/history/README.md
@@ -1,6 +1,6 @@
-# Verification result history
+# Historical verification-result archive
 
-This directory preserves historical verification-result objects or superseded current-result captures.
+This directory stores superseded or historical verification-result entry surfaces.
 
-Anything here is historical lineage material only.
-It must not outrank `verification/results/current/verification-result-0001.json` as the active current verification-result object.
+They must not outrank `verification/results/current/verification-result-0001.json`.
+They must not outrank `verification/results/current/index.json`.


### PR DESCRIPTION
## What this changes

- publishes the current VERIFRAX verification-result index
- binds the current verification-result object to the active accepted epoch, authority object, execution receipt, recognition object, recourse object, continuity object, and transfer object
- hardens the current cross-stack chain bundle so an outsider can replay the active chain from objects rather than prose
- adds explicit verification coverage for the current end-to-end chain surface

## Why this change

The active public chain must answer, from machine-readable objects alone:

claim class -> law version -> accepted epoch -> authority object -> execution receipt -> verification result -> recognition object -> recourse object -> continuity/transfer

This patch closes the current gap by making the verification surface and chain bundle explicit, typed, and test-backed.

## Boundary

This change strengthens object publication and chain readability only.

It does not alter law authorship, accepted-state authority, authority issuance, execution semantics, terminal recognition doctrine, or terminal recourse doctrine.
