### PR TITLE
Clarify VERIFRAX public chamber topology and implementation strata

### DIFF
--- a/.github/profile/README.md
+++ b/.github/profile/README.md
@@ -3,5 +3,31 @@ VERIFRAX v2.5.0 is the terminal and final authoritative version.
 Canonical authority:
 https://github.com/Verifrax/VERIFRAX (tag: v2.5.0, signed)
 
-All other repositories are subordinate or non-authoritative.
+All other repositories are subordinate or non-authoritative.\n
 
+## Public chamber topology
+
+The public sovereign chamber reading of VERIFRAX is:
+
+1. **SYNTAGMARIUM** — constitutional law
+2. **ORBISTIUM** — accepted epoch / accepted state
+3. **CONSONORIUM** — runtime reconciliation under subordinate boundaries
+4. **AUCTORISEAL** — authority issuance and authority reference
+5. **CORPIFORM** — governed execution and execution receipts
+6. **VERIFRAX** — verification result, evidence root, and cross-stack chain binding
+7. **TACHYRIUM** — subordinate cognition only
+8. **ANAGNORIUM** — terminal recognition
+9. **REGRESSORIUM** — terminal recourse
+
+These chambers are role-distinct and must not be collapsed into one another.
+
+## Implementation strata and host-role separation
+
+The public implementation and host strata are subordinate support surfaces, not sovereign chambers.
+
+- **VERIFRAX-WWW** — root/public web presentation only
+- **VERIFRAX-API** — API/transport surface only
+- **VERIFRAX-STATUS** — status publication only
+- **VERIFRAX-SURFACE** — form and host-system presentation only
+
+None of those implementation strata define constitutional law, accepted state, authority of record, execution legitimacy, terminal recognition, terminal recourse, or final verification truth.


### PR DESCRIPTION
## What changed

This change strengthens the public reading lock in the org profile.

It makes the chamber topology explicit across the nine sovereign chambers:
- SYNTAGMARIUM
- ORBISTIUM
- CONSONORIUM
- AUCTORISEAL
- CORPIFORM
- VERIFRAX
- TACHYRIUM
- ANAGNORIUM
- REGRESSORIUM

It also names the implementation strata explicitly so hostile readers do not confuse them with sovereign chambers:
- VERIFRAX-WWW
- VERIFRAX-API
- VERIFRAX-STATUS
- VERIFRAX-SURFACE

## Why

The five-gate finish audit found Gate B red only because the org profile did not make the public chamber topology and implementation strata explicit enough.

This patch resolves that public-reading ambiguity without changing law, accepted state, authority, execution, verification, recognition, recourse, continuity, or transfer objects.

## Boundary

This PR changes org-profile reading only.

It does not:
- alter canonical law
- alter accepted epoch truth
- alter authority issuance
- alter execution receipts
- alter verification results
- alter recognition objects
- alter recourse objects
- alter continuity or transfer state
