### PR TITLE
Align VERIFRAX verification active-truth typing and receipt binding

### DIFF
--- a/verification/results/current/index.json
+++ b/verification/results/current/index.json
@@ -9,7 +9,9 @@
       "verification_result_id": "verification-result-0001",
       "path": "verification/results/current/verification-result-0001.json",
       "receipt_id": "8F88E46F-625B-4682-BF9A-D68ADD241FFF",
-      "authority_seal_id": "seal_9c1568bb9ef7423283ca56ecdb7dc278"
+      "authority_seal_id": "seal_9c1568bb9ef7423283ca56ecdb7dc278",
+      "receipt_ref": "https://github.com/Verifrax/CORPIFORM/blob/main/receipts/current/execution-receipt-0001.json"
     }
-  ]
+  ],
+  "state_type": "ACTIVE_TRUTH"
 }

--- a/verification/results/current/verification-result-0001.json
+++ b/verification/results/current/verification-result-0001.json
@@ -32,5 +32,7 @@
   "recognition_object_ref": "https://github.com/Verifrax/ANAGNORIUM/blob/main/recognitions/current/recognition-object-0001.json",
   "recourse_object_ref": "https://github.com/Verifrax/REGRESSORIUM/blob/main/claims/current/recourse-object-0001.json",
   "continuity_ref": "evidence/continuity/current/continuity-object-0001.json",
-  "transfer_ref": "evidence/transfer/current/transfer-object-0001.json"
+  "transfer_ref": "evidence/transfer/current/transfer-object-0001.json",
+  "state_type": "ACTIVE_TRUTH",
+  "receipt_ref": "https://github.com/Verifrax/CORPIFORM/blob/main/receipts/current/execution-receipt-0001.json"
 }


### PR DESCRIPTION
## What changed
- aligned current verification index to explicit active-truth typing
- aligned current verification result object to explicit active-truth typing
- aligned verification result receipt binding to the canonical CORPIFORM current execution-receipt object

## Why
This closes the current-truth integrity red gate for the active VERIFRAX verification surface and removes ambiguity about whether the current verification path is active truth and which receipt surface it binds to.

## Boundary
This change updates only VERIFRAX current verification truth typing and receipt binding.

It does not change law version, accepted epoch, authority issuance, execution logic, recognition logic, recourse logic, continuity rules, or transfer rules.

## Verification
- gate-a verification index active truth
- gate-a verification result active truth
- gate-a chain->verification id singular
- gate-a chain verification ref canonical
- gate-a receipt ref canonical
