### PR TITLE
Align VERIFRAX continuity and transfer active-truth typing

### DIFF
--- a/evidence/continuity/current/continuity-object-0001.json
+++ b/evidence/continuity/current/continuity-object-0001.json
@@ -30,5 +30,6 @@
   "notes": [
     "This object states how bounded replay continuity is preserved for the current active chain.",
     "It does not replace law, authority, verification, recognition, recourse, or freeze objects."
-  ]
+  ],
+  "state_type": "ACTIVE_TRUTH"
 }

--- a/evidence/transfer/current/transfer-object-0001.json
+++ b/evidence/transfer/current/transfer-object-0001.json
@@ -27,5 +27,6 @@
   "notes": [
     "This object defines the bounded transfer reading for continuity of the active chain.",
     "It is not a substitute for chamber objects or governance authority."
-  ]
+  ],
+  "state_type": "ACTIVE_TRUTH"
 }


### PR DESCRIPTION
## What changed
- align continuity object active-truth typing
- align transfer object active-truth typing

## Why
Gate E required continuity and transfer current objects to read as active truth rather than impersonable or weaker current-state material.

## Boundary
This change updates active-truth typing only.
It does not change authority routing, verification binding, continuity semantics, transfer semantics, or chain topology.

## Verification
- verified continuity object is ACTIVE_TRUTH
- verified transfer object is ACTIVE_TRUTH
- verified continuity remains bound to current verification result
- verified transfer remains bound to current authority object
- verified continuity/transfer minimum tests and verifier remain present
