### PR TITLE
Harden VERIFRAX current chain bundle replay bindings

### DIFF
--- a/evidence/chain/current/cross-stack-chain-bundle-0001.json
+++ b/evidence/chain/current/cross-stack-chain-bundle-0001.json
@@ -22,7 +22,9 @@
     "continuity_object": "evidence/continuity/current/continuity-object-0001.json",
     "transfer_object": "evidence/transfer/current/transfer-object-0001.json",
     "continuity": "evidence/continuity/current/continuity-object-0001.json",
-    "transfer": "evidence/transfer/current/transfer-object-0001.json"
+    "transfer": "evidence/transfer/current/transfer-object-0001.json",
+    "continuity_ref": "evidence/continuity/current/continuity-object-0001.json",
+    "transfer_ref": "evidence/transfer/current/transfer-object-0001.json"
   },
   "index_refs": {
     "chain_index": "evidence/chain/current/index.json",
@@ -78,5 +80,6 @@
     "verification_result_match": true,
     "continuity_match": true,
     "transfer_match": true
-  }
+  },
+  "state_type": "ACTIVE_TRUTH"
 }


### PR DESCRIPTION
## Summary
Harden the current public chain bundle so replay-critical bindings are explicit and machine-readable.

## What changed
- mark the current chain bundle as active truth
- bind the current chain bundle explicitly to:
  - current verification result
  - current continuity object
  - current transfer object

## Why
Finish-grade replay hardening requires the current chain bundle to expose canonical replay bindings directly from bounded objects, not from prose or inference.

## Boundary
This change hardens replay/readability only.
It does not expand law, accepted state, authority, execution, verification scope, recognition scope, recourse scope, or continuity scope.
