### PR TITLE
Type VERIFRAX public chain index and chain bundle surfaces

### DIFF
--- a/evidence/chain/current/cross-stack-chain-bundle-0001.json
+++ b/evidence/chain/current/cross-stack-chain-bundle-0001.json
@@ -1,5 +1,5 @@
 {
-  "object_type": "CrossStackChainBundle",
+  "object_type": "CROSS_STACK_CHAIN_BUNDLE",
   "chain_bundle_id": "cross-stack-chain-bundle-0001",
   "status": "ACTIVE_TRUTH",
   "subject_artifact_id": "artifact-0005",

--- a/evidence/chain/current/index.json
+++ b/evidence/chain/current/index.json
@@ -1,5 +1,5 @@
 {
-  "object_type": "CrossStackChainIndex",
+  "object_type": "CHAIN_INDEX",
   "status": "ACTIVE_TRUTH",
   "historical": false,
   "current_chain_bundle_ref": "evidence/chain/current/cross-stack-chain-bundle-0001.json",


### PR DESCRIPTION
## Summary
Type the public current chain index and current cross-stack chain bundle explicitly.

## What changed
- set `evidence/chain/current/index.json` to explicit `CHAIN_INDEX`
- set `evidence/chain/current/cross-stack-chain-bundle-0001.json` to explicit `CROSS_STACK_CHAIN_BUNDLE`

## Why
Finish-grade outsider replay hardening requires public replay surfaces to be machine-typed directly on the bounded objects, not inferred from filenames or prose.

## Boundary
This change hardens public replay surface typing only.
It does not expand law, accepted state, authority, execution, verification, recognition, recourse, continuity, or transfer scope.
