### PR TITLE
Clarify org profile non-sovereign boundary rejections

### DIFF
--- a/.github/profile/README.md
+++ b/.github/profile/README.md
@@ -53,3 +53,16 @@ The public implementation and host strata are subordinate support surfaces, not 
 - **VERIFRAX-SURFACE** — form and host-system presentation only
 
 None of those implementation strata define constitutional law, accepted state, authority of record, execution legitimacy, terminal recognition, terminal recourse, or final verification truth.
+
+
+
+## Non-sovereign reading lock
+
+The org profile is a public topology and orientation surface only.
+
+It is not itself law.  
+It is not itself state.  
+It is not itself reconciliation.  
+It is not itself cognition.  
+
+Readers must not treat the org profile as a substitute for constitutional law objects, accepted-state objects, reconciliation runtime objects, or bounded subordinate cognition outputs. The profile points to bounded chambers and implementation strata; it does not itself become a sovereign chamber by describing them.


### PR DESCRIPTION
## Summary
Make the org-profile reading lock explicitly reject sovereign over-reading.

## What changed
- added explicit non-sovereign rejection language to `.github/profile/README.md`
- made clear that the org profile is not itself:
  - law
  - state
  - reconciliation
  - cognition

## Why
The perimeter must not allow a hostile reader to mistake topology/orientation copy for sovereign chamber output. The org profile may point to chambers and implementation strata, but must not itself be readable as law, accepted state, runtime reconciliation, or cognition.

## Boundary
This patch changes perimeter reading only.
It does not mutate protocol law, accepted state, authority, execution, verification, recognition, recourse, continuity, transfer, or chain objects.
