### PR TITLE
Align VERIFRAX chain index active-truth typing

### DIFF
--- a/evidence/chain/current/index.json
+++ b/evidence/chain/current/index.json
@@ -12,5 +12,6 @@
       "recognition_object_id": "recognition-object-0001",
       "recourse_object_id": "recourse-object-0001"
     }
-  ]
+  ],
+  "state_type": "ACTIVE_TRUTH"
 }


### PR DESCRIPTION
## Summary
Align the current chain index with explicit active-truth typing.

## What changed
- set `evidence/chain/current/index.json` to explicit `ACTIVE_TRUTH`

## Why
The public chain index must read as current active truth, not as an ambiguous or weaker surface. This keeps the public cross-stack object path machine-readable and consistent with the current chain bundle.

## Boundary
This patch changes chain-index typing only.
It does not mutate law, epoch, authority, receipt, verification result, continuity, transfer, recognition, recourse, or chamber topology.
