### PR TITLE
Align package version to published 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "bin": {
     "verifrax-seal": "scripts/verifrax-seal.js"
   },
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Package version in package.json lagged behind the published npm latest version.

Scope:
- align local package.json version to the already-published npm latest
- clear package-version audit drift only
- no release/tag/publish action in this PR