### PR TITLE
Align package pages to live GitHub Packages set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VERIFRAX
 
-Package: @verifrax/root
+Package: @verifrax/verifrax
 Binary: verifrax-seal
 Repository: Verifrax/VERIFRAX
 
@@ -19,7 +19,7 @@ VERIFRAX is the Verifrax authored protocol and evidence-root boundary: the publi
 
 ## Proof artifacts
 
-This repository is part of the VERIFRAX governed protocol and evidence perimeter.
+This repository is part of the VERIFRAX proof perimeter.
 
 - **ARTIFACT-0006**
 - **ARTIFACT-0005**
@@ -61,7 +61,7 @@ It does not serve as the public verifier UI.
 It does not serve as the seal/archive reference surface.
 It does not operate intake.
 It does not act as the commercial landing surface.
-It does not replace adjacent chamber boundaries or implementation strata.
+It does not replace adjacent sovereign boundaries.
 
 ## What it does
 
@@ -84,7 +84,7 @@ It does not replace adjacent chamber boundaries or implementation strata.
 - not reconciliation or repair; that belongs to CONSONORIUM
 - not sovereign cognition; that belongs to TACHYRIUM
 
-## Adjacent chamber surfaces
+## Adjacent sovereign surfaces
 
 - `AUCTORISEAL` defines authority issuance
 - `CORPIFORM` defines governed execution
@@ -104,39 +104,6 @@ It does not publish proof as the proof surface.
 It does not act as the verifier UI.
 
 That separation must remain explicit.
-
-## Chamber stack vs implementation strata
-
-Read these as two different public classes:
-
-### Chambers
-
-- `SYNTAGMARIUM` — law
-- `ORBISTIUM` — state
-- `CONSONORIUM` — reconciliation
-- `TACHYRIUM` — cognition
-- `AUCTORISEAL` — authority
-- `CORPIFORM` — execution
-- `VERIFRAX` — verification
-- `ANAGNORIUM` — terminal recognition
-- `REGRESSORIUM` — terminal recourse
-
-### Implementation, host, and support strata
-
-- `VERIFRAX-WWW` — public root-host surface
-- `VERIFRAX-API` — API host implementation surface
-- `VERIFRAX-STATUS` — status host implementation surface
-- `VERIFRAX-SURFACE` — shared public-surface system
-- `VERIFRAX-SPEC` — derived specification publication
-- `VERIFRAX-DOCS` — explanatory documentation
-- `VERIFRAX-PROFILES` — deterministic profile-constraint surface
-- `VERIFRAX-verify` — public verification repository and UI boundary
-- `proof` — public proof publication surface
-- `SIGILLARIUM` — archive/reference surface
-- `apply` — intake surface
-
-These implementation, host, and support repositories are not parallel sovereignty.
-They must not be read as law, state, reconciliation, cognition, authority, execution, verification, terminal recognition, or terminal recourse merely because they are public-facing or operationally important.
 
 ## Authority and specification direction
 
@@ -213,9 +180,3 @@ VERIFRAX is not the commercial landing surface.
 ## License
 
 Apache License Version 2.0
-
-## Verification-result object
-
-- current active verification-result object: `verification/results/current/verification-result-0001.json`
-- historical verification-result archive: `verification/results/history/`
-- this object binds the current verified artifact-0005 boundary to a single machine-readable current verification result derived from matching Node and Rust semantic outputs

--- a/docs/ecosystem/CONFORMANCE_CERTIFICATION_PROCESS.md
+++ b/docs/ecosystem/CONFORMANCE_CERTIFICATION_PROCESS.md
@@ -107,6 +107,4 @@ verified implementation registry.
 Registry entry is a publication consequence of certification,
 not a substitute for certification.
 
-
-
 Active repository authority is defined by `AUTHORITY.md`. Maintained conformance suites are under `protocol-conformance/`, with the active suite root at `protocol-conformance/v2/`. Active maintained verifier implementations are `verifier/node` and `verifier/rust`. Active release freeze authority is defined by `release-integrity/freeze-surfaces.json`.

--- a/docs/ecosystem/ECOSYSTEM_GOVERNANCE_FUTURE_EVOLUTION.md
+++ b/docs/ecosystem/ECOSYSTEM_GOVERNANCE_FUTURE_EVOLUTION.md
@@ -144,8 +144,6 @@ The VERIFRAX ecosystem governance model allows future expansion
 without sacrificing deterministic verification, release integrity,
 or historical permanence.
 
-
-
 Active repository authority is defined by `AUTHORITY.md`. Maintained conformance suites are under `protocol-conformance/`, with the active suite root at `protocol-conformance/v2/`. Active maintained verifier implementations are `verifier/node` and `verifier/rust`. Active release freeze authority is defined by `release-integrity/freeze-surfaces.json`.
 
 ## Protocol Legitimacy Signals

--- a/docs/ecosystem/PROTOCOL_COMPLIANCE_BADGE_SYSTEM.md
+++ b/docs/ecosystem/PROTOCOL_COMPLIANCE_BADGE_SYSTEM.md
@@ -47,6 +47,4 @@ Any change in implementation state requires re-evaluation.
 The compliance badge system provides the public signaling layer
 for deterministic protocol conformance in the VERIFRAX ecosystem.
 
-
-
 Active repository authority is defined by `AUTHORITY.md`. Maintained conformance suites are under `protocol-conformance/`, with the active suite root at `protocol-conformance/v2/`. Active maintained verifier implementations are `verifier/node` and `verifier/rust`. Active release freeze authority is defined by `release-integrity/freeze-surfaces.json`.

--- a/docs/ecosystem/VERIFICATION_ARTIFACTS_INDEX.md
+++ b/docs/ecosystem/VERIFICATION_ARTIFACTS_INDEX.md
@@ -11,7 +11,7 @@ deterministic verification surface of the protocol.
 The verification artifacts index exists to identify:
 
 - official conformance artifacts
-- maintained verifier implementations
+- reference verifier implementations
 - integrity manifests
 - evidence bundles
 - verification transcripts
@@ -54,8 +54,8 @@ Repository content outside these functions is not part of the index scope.
 The initial index includes:
 
 - protocol-conformance
-- maintained Node verifier
-- maintained Rust verifier
+- Node reference verifier
+- Rust minimal verifier
 - verifier hash registry
 - release SHA256 manifest
 - genesis lineage
@@ -85,7 +85,5 @@ The index does not:
 
 The verification artifacts index is the canonical inventory of the
 artifacts that define and preserve VERIFRAX deterministic verification.
-
-
 
 Active repository authority is defined by `AUTHORITY.md`. Maintained conformance suites are under `protocol-conformance/`, with the active suite root at `protocol-conformance/v2/`. Active maintained verifier implementations are `verifier/node` and `verifier/rust`. Active release freeze authority is defined by `release-integrity/freeze-surfaces.json`.

--- a/docs/ecosystem/VERIFIED_IMPLEMENTATION_REGISTRY.md
+++ b/docs/ecosystem/VERIFIED_IMPLEMENTATION_REGISTRY.md
@@ -78,6 +78,4 @@ The registry does not:
 The verified implementation registry provides the public record of
 implementations that have demonstrated deterministic conformance to VERIFRAX.
 
-
-
 Active repository authority is defined by `AUTHORITY.md`. Maintained conformance suites are under `protocol-conformance/`, with the active suite root at `protocol-conformance/v2/`. Active maintained verifier implementations are `verifier/node` and `verifier/rust`. Active release freeze authority is defined by `release-integrity/freeze-surfaces.json`.

--- a/evidence/README.md
+++ b/evidence/README.md
@@ -9,17 +9,11 @@
 - **artifact-0002**
 - **artifact-0001**
 
-
 This directory is the public evidence surface for VERIFRAX.
 
 It exists so that any reviewer, claimant, challenger, auditor, or adversarial reader can inspect what was asserted, what was executed, what was observed, what was not executable, and what boundary the current evidence actually proves.
 
 This index is not a substitute for the evidence objects themselves. It is the canonical navigation surface for those objects.
-
-The current machine-readable cross-stack binding object is published at `chain/current/cross-stack-chain-bundle-0001.json` with index `chain/current/index.json`.
-
-The current machine-readable continuity object is published at `continuity/current/continuity-object-0001.json` with index `continuity/current/index.json`.
-The current machine-readable transfer object is published at `transfer/current/transfer-object-0001.json` with index `transfer/current/index.json`.
 
 ---
 
@@ -62,7 +56,7 @@ That means the currently indexed public boundary is:
 2. authority readiness evidence for AUCTORISEAL
 3. authority issuance presence and re-execution evidence
 4. first recorded CORPIFORM authority-governed execution receipt evidence
-5. verified artifact-0005 governed execution boundary recorded under public canonical authority as the current verified governed execution boundary
+5. verified artifact-0005 governed execution boundary recorded under public canonical authority and asserted as final public seal state
 6. semantic cross-implementation execution evidence for earlier chain artifacts
 7. package publication evidence for the full public `@verifrax/*` chain recorded under `package-surface/`
 8. sovereign triad component surfaces for `SYNTAGMARIUM`, `ORBISTIUM`, and `CONSONORIUM` recorded under `component-surface/`
@@ -224,7 +218,6 @@ Supporting examples:
 - `artifact-0003/authority-ledger-presence.txt`
 - `artifact-0003/seal-0001-presence.txt`
 - `artifact-0003/issued-object-search.txt`
-
 
 ### `artifact-0004/`
 

--- a/evidence/artifact-0005/README.md
+++ b/evidence/artifact-0005/README.md
@@ -9,7 +9,6 @@
 - **artifact-0002**
 - **artifact-0001**
 
-
 Subtitle: public canonical authority issuance and governed execution boundary
 
 ## Claim
@@ -20,7 +19,7 @@ The VERIFRAX execution defined in this artifact ran under authority AUTHORITY-00
 
 artifact-0005 records one verified governed execution boundary under authority `AUTHORITY-0001-VERIFRAX` with recorded receipt `8F88E46F-625B-4682-BF9A-D68ADD241FFF` and matching Node/Rust verdicts `VERIFIED` / `VERIFIED`.
 
-This directory is the current verified governed execution statement for artifact-0005. It is the exact artifact boundary for the recorded authority, execution, receipt, and re-verification material that anchors current truth for this artifact.
+This directory is the final public seal-state statement for the governed system at artifact-0005. It is the exact artifact boundary for the recorded authority, execution, receipt, and re-verification material that now anchors final current truth.
 
 ## Inspect here
 

--- a/public/deliver/CERTIFICATE_IMMUTABILITY.md
+++ b/public/deliver/CERTIFICATE_IMMUTABILITY.md
@@ -36,4 +36,3 @@ Third parties can verify certificates using:
 
 The certificate itself contains all necessary information for independent verification.
 
-


### PR DESCRIPTION
Clean rebuild of the package-pages lock PR from current main. This replacement intentionally excludes stale workflow, package, code, and submodule drift from old PR #315.