### PR TITLE
Align evidence current spine to artifact-0006

### DIFF
--- a/evidence/CONSISTENCY_AUDIT.txt
+++ b/evidence/CONSISTENCY_AUDIT.txt
@@ -2,6 +2,7 @@ VERIFRAX ROOT CONSISTENCY AUDIT
 STATUS: CURRENT-STATE CONSISTENCY RECORDED
 
 AUDIT_SCOPE:
+- evidence/artifact-0006/artifact.json
 - evidence/README.md
 - evidence/bootstrap-chain-status/CHAIN_STATUS.txt
 - evidence/CURRENT_STATE_INDEX.txt
@@ -11,6 +12,7 @@ AUDIT_SCOPE:
 - evidence/artifact-0005/CROSS_IMPLEMENTATION_STATUS.txt
 
 CURRENT_TRUTH_RESULTS:
+- ARTIFACT-0006 is materialized as the terminal recognition and terminal recourse surface extension.
 - ARTIFACT-0004 remains RECORDED and bounded by consumed fixture authority evidence only.
 - ARTIFACT-0004 stale registration instruction has been removed from EXECUTION_STATUS.txt.
 - ARTIFACT-0005 is registered in the evidence root as VERIFIED.
@@ -21,6 +23,7 @@ CURRENT_TRUTH_RESULTS:
 - CURRENT_STATE_INDEX.txt, evidence/README.md, and bootstrap-chain-status/CHAIN_STATUS.txt now tell the same current artifact-chain story without broader completion overclaim.
 
 AUDIT_FINDINGS:
+- CURRENT ROOT ARTIFACT-0006 MATERIALIZATION LINE IS PRESENT AND ALIGNED.
 - CURRENT ROOT CONTRADICTION FOR ARTIFACT-0005 REGISTRATION STATUS HAS BEEN REMOVED BY ALIGNING ALL CURRENT-TRUTH FILES TO VERIFIED REGISTERED STATE.
 - CURRENT ROOT CONTRADICTION FOR ARTIFACT-0005 VERDICT STATUS HAS BEEN REMOVED BY ALIGNING ALL CURRENT-TRUTH FILES TO VERIFIED STATE.
 - NO CURRENT ROOT CONTRADICTION FOUND FOR ARTIFACT-0004 BOUNDARY LIMIT.

--- a/evidence/CURRENT_STATE_INDEX.txt
+++ b/evidence/CURRENT_STATE_INDEX.txt
@@ -9,6 +9,7 @@ RULES:
 - The recorded artifact-0005 boundary is asserted here as the current verified governed execution anchor.
 
 CURRENT_ARTIFACT_CHAIN:
+- ARTIFACT-0006 = MATERIALIZED
 - ARTIFACT-0001 = VERIFIED
 - ARTIFACT-0002 = VERIFIED
 - ARTIFACT-0003 = VERIFIED
@@ -16,6 +17,7 @@ CURRENT_ARTIFACT_CHAIN:
 - ARTIFACT-0005 = VERIFIED
 
 CURRENT_ARTIFACT_MEANING:
+- ARTIFACT-0006 records terminal recognition and terminal recourse surface materialization through ANAGNORIUM and REGRESSORIUM without replacing artifact-0005 as the verified governed execution anchor.
 - ARTIFACT-0001 records repository integrity and initial protocol object grounding.
 - ARTIFACT-0002 records authority readiness evidence and now-resolved semantic validation.
 - ARTIFACT-0003 records public issuance-subject presence with matching Node and Rust semantic validation.
@@ -23,6 +25,8 @@ CURRENT_ARTIFACT_MEANING:
 - ARTIFACT-0005 records public canonical authority-governed execution, recorded CORPIFORM receipt material, and matching Node and Rust semantic verification outputs.
 
 CURRENT_BOUNDARY:
+- Artifact-0006 currently defines the terminal recognition and recourse materialization extension of the evidence chain.
+- Artifact-0006 does not replace artifact-0005 as the verified governed execution and final seal-state anchor.
 - The bootstrap chain is semantically resolved through artifact-0003.
 - The execution boundary is extended by artifact-0004 recorded receipt evidence.
 - Artifact-0005 currently defines the verified governed execution boundary that anchors the current root truth boundary.
@@ -52,6 +56,7 @@ CURRENT_ARTIFACT_0005_BINDING:
 - TRANSFER_INDEX: evidence/transfer/current/index.json
 
 CURRENT_ROOT_SURFACES:
+- ARTIFACT_0006_PRIMARY: evidence/artifact-0006/artifact.json
 - EVIDENCE_INDEX: evidence/README.md
 - CHAIN_STATUS: evidence/bootstrap-chain-status/CHAIN_STATUS.txt
 - ARTIFACT_0005_PRIMARY: evidence/artifact-0005/artifact-0005.json

--- a/evidence/README.md
+++ b/evidence/README.md
@@ -21,6 +21,7 @@ This index is not a substitute for the evidence objects themselves. It is the ca
 
 Current bootstrap-chain status:
 
+- **ARTIFACT-0006:** MATERIALIZED
 - **ARTIFACT-0001:** VERIFIED
 - **ARTIFACT-0002:** VERIFIED
 - **ARTIFACT-0003:** VERIFIED
@@ -60,6 +61,7 @@ That means the currently indexed public boundary is:
 6. semantic cross-implementation execution evidence for earlier chain artifacts
 7. package publication evidence for the full public `@verifrax/*` chain recorded under `package-surface/`
 8. sovereign triad component surfaces for `SYNTAGMARIUM`, `ORBISTIUM`, and `CONSONORIUM` recorded under `component-surface/`
+9. terminal recognition and terminal recourse surfaces materialized through artifact-0006 without replacing artifact-0005 as the final seal-state anchor
 
 ---
 
@@ -81,6 +83,7 @@ This tells you what the currently accepted boundary is for the bootstrap chain.
 
 Read the artifact directories if you want to inspect the declared subject, claim set, and collected evidence objects for each protocol artifact.
 
+- `artifact-0006/`
 - `artifact-0001/`
 - `artifact-0002/`
 - `artifact-0003/`
@@ -242,6 +245,27 @@ Supporting examples:
 - `artifact-0004/receipt.sha256`
 - `artifact-0004/receipt.canonical.sha256`
 - `artifact-0004/EXECUTION_STATUS.txt`
+
+### `artifact-0006/`
+
+Purpose:
+
+- terminal constitutional consequence surface materialization
+
+Use this when checking:
+
+- whether terminal recognition is publicly materialized through ANAGNORIUM
+- whether terminal recourse is publicly materialized through REGRESSORIUM
+- whether artifact-0006 extends artifact-0005 without replacing artifact-0005 as the verified governed execution and final seal-state anchor
+
+Primary file:
+
+- `artifact-0006/artifact.json`
+
+Boundary:
+
+- artifact-0006 does not rerun, replace, or supersede the artifact-0005 governed execution receipt.
+- artifact-0006 records the materialization of terminal recognition and terminal recourse surfaces as bounded public repository surfaces.
 
 ### `artifact-0005/`
 

--- a/evidence/STATUS_AUTHORITY_MAP.txt
+++ b/evidence/STATUS_AUTHORITY_MAP.txt
@@ -26,6 +26,7 @@ CURRENT_AUTHORITY_ROOT:
 - GOVERNANCE_BINDING_RULE = Governance authority is external and bound through AUCTORISEAL plus .github governed repo set.
 
 ARTIFACT_STATUS_BINDINGS:
+- ARTIFACT-0006 = MATERIALIZED
 - ARTIFACT-0001 = VERIFIED
 - ARTIFACT-0002 = VERIFIED
 - ARTIFACT-0003 = VERIFIED
@@ -50,12 +51,18 @@ ARTIFACT-0005 AUTHORITY BOUNDARY:
 - CANONICAL_SEMANTIC_SHA256 = 801c87f08221ac194282b1a2e7f58cac2dcc143f6944c98a888edc086a72fc6b
 - STATUS = VERIFIED
 
+ARTIFACT-0006 TERMINAL BOUNDARY:
+- TERMINAL_RECOGNITION_SURFACE = github.com/Verifrax/ANAGNORIUM
+- TERMINAL_RECOURSE_SURFACE = github.com/Verifrax/REGRESSORIUM
+- STATUS = MATERIALIZED
+- LIMIT = artifact-0006 materializes terminal surfaces and does not replace artifact-0005 as the verified governed execution and final seal-state anchor
 MAPPING RULES:
 - artifact-0004 must remain bounded by consumed fixture authority evidence only.
 - artifact-0005 current-truth surfaces record a verified governed execution boundary with recorded input, execution, receipt, and matched verifier identifiers.
 - no root status surface may describe artifact-0004 as the public canonical authority basis.
 - root status surfaces describe artifact-0005 as the current verified governed execution boundary only.
 - current authority identifiers and current artifact-0005 identifiers must remain identical across the root status surfaces.
+- current status surfaces now describe artifact-0006 as the terminal materialization extension while preserving artifact-0005 as the verified governed execution anchor.
 
 CLOSURE STATE:
 - repo and docs truth surfaces outside the root evidence map are aligned to the root evidence perimeter

--- a/evidence/bootstrap-chain-status/CHAIN_STATUS.txt
+++ b/evidence/bootstrap-chain-status/CHAIN_STATUS.txt
@@ -1,3 +1,4 @@
+ARTIFACT-0006: MATERIALIZED ARTIFACT-0006-NOTE: terminal recognition and terminal recourse surfaces are materialized through ANAGNORIUM and REGRESSORIUM; artifact-0006 extends artifact-0005 without replacing artifact-0005 as the verified governed execution and final seal-state anchor.
 ARTIFACT-0001: VERIFIED
 ARTIFACT-0002: VERIFIED
 ARTIFACT-0002-NOTE: authority ledger and genesis seal are now present in declared evidence; node and rust semantic evaluators produced VERIFIED outputs
@@ -16,3 +17,5 @@ RELEASE_GATE_STATUS: verified governed execution is recorded in current truth; n
 
 PACKAGE-SURFACE-CHAIN: RECORDED
 PACKAGE-SURFACE-CHAIN-NOTE: public @verifrax package chain from primitives through sigillarium is live and recorded under evidence/package-surface/CURRENT_PACKAGE_INDEX.txt
+
+CURRENT_TERMINAL_EXTENSION: artifact-0006 materializes terminal recognition and terminal recourse surfaces while artifact-0005 remains the verified governed execution and final seal-state anchor.


### PR DESCRIPTION
Aligns the evidence current-state spine with the live artifact-0006 terminal materialization surface.

Scope:
- adds artifact-0006 to evidence current boundary summaries
- preserves artifact-0005 as verified governed execution and final seal-state anchor
- records artifact-0006 as terminal recognition and terminal recourse materialization
- no runtime change
- no package publication change
- no host change
- no topology expansion.