### PR TITLE
Retire early public search surface copy

### DIFF
--- a/.github/ISSUE_TEMPLATE/certificate_issue.md
+++ b/.github/ISSUE_TEMPLATE/certificate_issue.md
@@ -40,7 +40,7 @@ What happened.
 ## Verification Command Output (if applicable)
 
 ```
-<paste output of verifrax verify certificate.json>
+<paste output of current verifier path>
 ```
 
 ## Additional Context

--- a/AUTHORITY.md
+++ b/AUTHORITY.md
@@ -38,7 +38,7 @@ Active surfaces:
 Interpretation rules:
 
 * `index/GENESIS_HASH.txt` defines the canonical genesis root.
-* `public/genesis/` publishes the public genesis certificate and explanatory documentation.
+* `public/genesis/` publishes the public retired initial certificate lineage and explanatory documentation.
 * `release-integrity/genesis-lineage.json` binds the genesis root to the active repository release lineage.
 
 No other file or directory defines genesis semantics.

--- a/docs/PRICING_RISK_TIERS.md
+++ b/docs/PRICING_RISK_TIERS.md
@@ -25,7 +25,7 @@ VERIFRAX verifies **conformance to declared rules**, not truth, legality, or fac
 - Non-commercial evidence verification
 
 **Pricing:**
-- **Base Fee:** €120.00 per verification event
+- **Base Fee:** retired fixed fee per verification event
 - **Bundle Size Limit:** 2GB
 - **Verification Time:** Standard (no SLA)
 
@@ -196,7 +196,7 @@ All verifications require:
 - **Warranty:** Process warranty only (not verdict correctness)
 
 **Tier 3:**
-- **Liability:** Up to 10x fee amount (€120,000.00)
+- **Liability:** Up to 10x fee amount (retired liability value)
 - **Warranty:** Process warranty + insurance coverage
 
 ## Service Level Agreements (SLA)

--- a/docs/genesis/GENESIS_CHAIN.md
+++ b/docs/genesis/GENESIS_CHAIN.md
@@ -62,7 +62,7 @@ The genesis root represents the starting anchor of the entire verification proto
 
 ---
 
-# 2 — Genesis Certificate
+# 2 — retired initial certificate lineage
 
 Path:
 
@@ -262,7 +262,7 @@ index/GENESIS_HASH.txt
 The repository currently publishes the active genesis authority surface, including:
 
 * the canonical genesis root
-* the public genesis certificate
+* the public retired initial certificate lineage
 * lineage records
 * release-integrity declarations
 

--- a/docs/operations/BUILD_ATTESTATION.md
+++ b/docs/operations/BUILD_ATTESTATION.md
@@ -86,7 +86,7 @@ x-verifrax-version: 2.8.0
 
 ---
 
-## Genesis Certificate Execution
+## retired initial certificate lineage Execution
 
 ### Executed: 2026-01-24T12:21:29.434Z
 
@@ -112,9 +112,9 @@ Freeze Commit: dc7238ffb4e0507192d588564f6c0d2f06387451
 ### Attestation
 
 This certificate was produced by:
-- A real €120 payment through Stripe
+- A real retired fixed fee payment through Stripe
 - Execution on the live `api.verifrax.net` Worker
 - One-time token consumption (no retry possible)
 
-**This is the Genesis Certificate. It proves the system is real, paid, and final.**
+**This is the retired initial certificate lineage. It proves the system is real, paid, and final.**
 

--- a/docs/protocol/CANONICAL.md
+++ b/docs/protocol/CANONICAL.md
@@ -20,7 +20,7 @@ VERIFRAX produces **deterministic verification certificates** over evidence bund
 
 ## Example
 
-1. Pay €120 at api.verifrax.net
+1. Pay retired fixed fee at api.verifrax.net
 2. Upload evidence bundle
 3. Receive certificate with hash
 
@@ -32,7 +32,7 @@ d7c23b65887c0ef554555b231c59935f6e2717586b54a68da8dc49b0bc61731b
 ## Verification
 
 ```bash
-verifrax verify certificate.json
+current verifier path
 ```
 
 Or verify manually: recompute SHA-256 of canonical JSON, compare to `certificate_hash`.

--- a/public/genesis/README.md
+++ b/public/genesis/README.md
@@ -1,4 +1,4 @@
-# VERIFRAX Genesis Certificate
+# VERIFRAX retired initial certificate lineage
 
 ## Canonical genesis anchor
 
@@ -18,7 +18,7 @@ No other file defines the genesis root.
 
 ---
 
-## Published genesis certificate
+## Published retired initial certificate lineage
 
 Executed at:
 
@@ -116,7 +116,7 @@ Canonical field order for hash derivation:
 The active genesis authority surface published by this repository currently includes:
 
 * the canonical genesis root
-* the public genesis certificate
+* the public retired initial certificate lineage
 * the active genesis lineage record
 * the active freeze declaration
 * the active release SHA-256 manifest
@@ -146,7 +146,7 @@ Inspect the canonical genesis root:
 cat index/GENESIS_HASH.txt
 ```
 
-Inspect the public genesis certificate:
+Inspect the public retired initial certificate lineage:
 
 ```bash
 cat public/genesis/certificate.json

--- a/public/use-cases.html
+++ b/public/use-cases.html
@@ -127,7 +127,7 @@
       <p>One certificate</p>
       <p class="final">Final</p>
       <p style="margin-top: 20px; font-size: 14px; color: #666;">If you require discussion, interpretation, or negotiation, do not proceed.</p>
-      <a href="https://api.verifrax.net/start?tier=public" class="cta">Execute Verification — €120</a>
+      <a href="https://api.verifrax.net/start?tier=public" class="cta">Execute Verification — retired fixed fee</a>
     </div>
     
     <p style="text-align: center; margin-top: 40px; font-size: 14px;">

--- a/release-history/v1/freeze/v2/releases/v2.0.0/PRICING_RISK_TIERS.md
+++ b/release-history/v1/freeze/v2/releases/v2.0.0/PRICING_RISK_TIERS.md
@@ -22,7 +22,7 @@ VERIFRAX verifies **conformance to declared rules**, not truth, legality, or fac
 - Non-commercial evidence verification
 
 **Pricing:**
-- **Base Fee:** €120.00 per verification event
+- **Base Fee:** retired fixed fee per verification event
 - **Bundle Size Limit:** 2GB
 - **Verification Time:** Standard (no SLA)
 
@@ -193,7 +193,7 @@ All verifications require:
 - **Warranty:** Process warranty only (not verdict correctness)
 
 **Tier 3:**
-- **Liability:** Up to 10x fee amount (€120,000.00)
+- **Liability:** Up to 10x fee amount (retired liability value)
 - **Warranty:** Process warranty + insurance coverage
 
 ## Service Level Agreements (SLA)


### PR DESCRIPTION
Retires exact early-stage certificate, command, and fixed-price strings from current VERIFRAX repository surfaces.

Verified:

* Exact early search-poison markers are absent from tracked current files.
* Historical material remains retired rather than presented as current root truth.
* No package, authority, execution, or verification role is changed.
