### PR TITLE
Harden verification result object

### DIFF
--- a/verification/current/index.json
+++ b/verification/current/index.json
@@ -1,0 +1,7 @@
+{
+  "object_type": "VerificationResultIndex",
+  "status": "ACTIVE_INDEX",
+  "current_verification_result_id": "verification-result-0001",
+  "current_verification_result_ref": "verification/current/verification-result-0001.json",
+  "truth_warning": "INDEX_POINTS_TO_VERIFICATION_RESULT_NOT_RECOGNITION"
+}

--- a/verification/current/verification-result-0001.json
+++ b/verification/current/verification-result-0001.json
@@ -1,0 +1,21 @@
+{
+  "object_type": "VerificationResult",
+  "verification_result_id": "verification-result-0001",
+  "status": "ACTIVE_TRUTH",
+  "claim_class": "verification-result",
+  "artifact_id": "artifact-0005",
+  "law_version_ref": "SYNTAGMARIUM/claim-classes/current/claim-class-admission-0001.json",
+  "accepted_epoch_ref": "ORBISTIUM/epochs/current/accepted-epoch-0001.json",
+  "authority_object_ref": "AUCTORISEAL/authorities/current/authority-object-0001.json",
+  "freeze_object_ref": "SYNTAGMARIUM/freeze/objects/current/freeze-object-0001.json",
+  "chain_lock_ref": "ORBISTIUM/chains/current/minimum-object-chain-lock-0001.json",
+  "replay_bundle_ref": "VERIFRAX/replay/current/replay-bundle-0001.json",
+  "verification_scope": "artifact-0005-under-frozen-chain-prefix",
+  "verification_passed": true,
+  "may_recognize_terminal_truth": false,
+  "may_assign_recourse": false,
+  "may_mutate_authority": false,
+  "may_mutate_accepted_epoch": false,
+  "may_infer_missing_truth": false,
+  "truth_warning": "VERIFICATION_RESULT_NOT_RECOGNITION_OBJECT"
+}


### PR DESCRIPTION
Adds verification-result-0001 and index as VERIFRAX active truth for artifact-0005 under the frozen chain prefix. The object binds verification to replay bundle, authority object, freeze object, accepted epoch, and chain lock, while refusing recognition or recourse authority.